### PR TITLE
Feature/#19 메인 페이지 디자인을 구현한다

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,6 @@ indent_size = 4
 ktlint_code_style = ktlint_official
 ktlint_ignore_back_ticked_identifier = true
 ktlint_standard_no-wildcard-imports = disabled
-ktlint_standard_function-naming = disabled
 
 ktlint_standard = enabled
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,8 @@ indent_size = 4
 [*.{kt,kts}]
 ktlint_code_style = ktlint_official
 ktlint_ignore_back_ticked_identifier = true
+ktlint_standard_no-wildcard-imports = disabled
+ktlint_standard_function-naming = disabled
 
 ktlint_standard = enabled
 

--- a/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
+++ b/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
@@ -23,22 +23,25 @@ class MainScreenKtTest {
         }
     }
 
+    /** 메인 페이지에 탑바가 화면에 보인다 */
     @Test
-    fun 메인페이지에_탑바가_화면에_보인다() {
+    fun topBarIsDisplayedOnMainPage() {
         rule
             .onNodeWithText("메인 페이지")
             .assertIsDisplayed()
     }
 
+    /** 메인 페이지에 글 발행 버튼이 화면에 보인다 */
     @Test
-    fun 메인페이지에_글_발행_버튼이_화면에_보인다() {
+    fun publishButtonIsDisplayedOnMainPage() {
         rule
             .onNodeWithText("글 발행하러 가기")
             .assertIsDisplayed()
     }
 
+    /** 메인 페이지에 발행 현황 확인 버튼이 화면에 보인다 */
     @Test
-    fun 메인페이지에_발행_현황_확인_버튼이_화면에_보인다() {
+    fun checkPublishStatusButtonIsDisplayedOnMainPage() {
         rule
             .onNodeWithText("발행 현황 확인하기")
             .assertIsDisplayed()

--- a/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
+++ b/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
@@ -1,0 +1,46 @@
+package com.erica.gamsung.core.presentation
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainScreenKtTest {
+    @get:Rule
+    val rule: ComposeContentTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        rule.setContent {
+            MainScreen()
+        }
+    }
+
+    @Test
+    fun 메인페이지에_탑바가_화면에_보인다() {
+        rule
+            .onNodeWithText("메인 페이지")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun 메인페이지에_글_발행_버튼이_화면에_보인다() {
+        rule
+            .onNodeWithText("글 발행하러 가기")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun 메인페이지에_발행_현황_확인_버튼이_화면에_보인다() {
+        rule
+            .onNodeWithText("발행 현황 확인하기")
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:theme="@style/Theme.Gamsung"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name=".core.presentation.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Gamsung">

--- a/app/src/main/java/com/erica/gamsung/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/MainActivity.kt
@@ -3,14 +3,11 @@ package com.erica.gamsung
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.erica.gamsung.core.presentation.MainScreen
 import com.erica.gamsung.ui.theme.GamsungTheme
 
 class MainActivity : ComponentActivity() {
@@ -18,35 +15,13 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             GamsungTheme {
-                // A surface container using the 'background' color from the theme
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
-                    Greeting("Android")
+                    MainScreen()
                 }
             }
-        }
-    }
-}
-
-@Composable
-fun Greeting(
-    name: String,
-    modifier: Modifier = Modifier,
-) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier,
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    GamsungTheme {
-        Column {
-            Greeting("Android")
         }
     }
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.erica.gamsung
+package com.erica.gamsung.core.presentation
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import com.erica.gamsung.core.presentation.MainScreen
 import com.erica.gamsung.ui.theme.GamsungTheme
 
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainScreen.kt
@@ -1,0 +1,67 @@
+package com.erica.gamsung.core.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.erica.gamsung.core.presentation.component.GsOutlinedButton
+import com.erica.gamsung.core.presentation.component.GsTopAppBar
+
+@Composable
+fun MainScreen() {
+    Scaffold(
+        topBar = {
+            GsTopAppBar(
+                title = "메인 페이지",
+                hasRightIcon = true,
+                onActionsClick = { TODO() },
+            )
+        },
+        modifier = Modifier.fillMaxSize(),
+    ) { paddingValues ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(paddingValues)
+                    .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            MainButton("글 발행하러 가기")
+
+            Spacer(modifier = Modifier.height(30.dp))
+
+            MainButton("발행 현황 확인하기")
+        }
+    }
+}
+
+@Composable
+private fun MainButton(text: String) {
+    GsOutlinedButton(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+                .padding(horizontal = 20.dp),
+        text = text,
+        fontSize = 25.sp,
+        onClick = { TODO() },
+    )
+}
+
+@Preview
+@Composable
+private fun MainScreenPreview() {
+    MainScreen()
+}

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsButton.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsButton.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 
 private val Green = Color(0xFF1F7158)
@@ -47,6 +48,7 @@ fun GsButton(
 fun GsOutlinedButton(
     modifier: Modifier = Modifier,
     text: String,
+    fontSize: TextUnit = TextUnit.Unspecified,
     onClick: () -> Unit = {},
 ) {
     OutlinedButton(
@@ -57,6 +59,7 @@ fun GsOutlinedButton(
                 text = text,
                 fontWeight = FontWeight.Bold,
                 color = Color.Black,
+                fontSize = fontSize,
             )
         },
         modifier = modifier,


### PR DESCRIPTION
## Issue
- close #19 

## Overview (Required)
- 메인 페이지 디자인을 구현한다.

## Links
-

## Screenshot
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/cdbab870-39f3-431c-bc6e-39ddaf3b6e97" width="300" />

---

메인 페이지 UI만 구현했고, 버튼 클릭 시 동작들은 TODO()로 표시해뒀어.
그리고 [Compose 레이아웃 테스트](https://developer.android.com/jetpack/compose/testing?hl=ko) 참고해서 테스트 작성해봤는데 아무래도 프로젝트 개발해가면서 익숙해져가야 할듯 ㅎ

이 과정에서 ktlint의 룰 조금 비활성화했어.
아무래도 기본적으로 테스트 코드 생성하면 자동으로 `org.junit.Assert.*`이 생성되다보니 해당 룰은 비활성화했어.

나는 테스트 코드는 하나의 문서라고 생각해서 테스트 코드를 처음 보는 사람이 내부 구현을 보지 않고 함수명만 보더라도 테스트하고자 하는 코드가 어떤 기능을 가질지 유추가능해야 하다고 생각하거든.
그렇다보니 영어는 잘 못해서 한글로 작성하는 걸 선호하는데 UI 테스트는  `Junit4`가  `@DisplayName`이 없더라고
 
그래서 `function-naming`룰 비활성화하고 함수명 한글로 적기 vs 함수명 영어로 적기 고민하다가 해당 룰 비활성화했어.
이건 어떻게 하는게 좋을지 의견좀 알려줘.