### PR TITLE
Feature/#10 메뉴 정보 입력 페이지 디자인을 구현한다

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,7 +63,6 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
-    implementation("androidx.navigation:navigation-compose:2.5.3")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
@@ -75,4 +74,8 @@ dependencies {
     // kotest
     testImplementation("io.kotest:kotest-runner-junit5:5.8.0")
     testImplementation("io.kotest:kotest-assertions-core:5.8.0")
+
+    // navigation
+    implementation("androidx.navigation:navigation-compose:2.5.3")
+    androidTestImplementation("androidx.navigation:navigation-testing:2.5.3")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,4 +78,7 @@ dependencies {
     // navigation
     implementation("androidx.navigation:navigation-compose:2.5.3")
     androidTestImplementation("androidx.navigation:navigation-testing:2.5.3")
+
+    // icons
+    implementation("androidx.compose.material:material-icons-extended:1.6.1")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,6 @@ android {
 }
 
 dependencies {
-
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
     implementation("androidx.activity:activity-compose:1.8.2")
@@ -64,6 +63,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.navigation:navigation-compose:2.5.3")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
+++ b/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
@@ -1,9 +1,14 @@
 package com.erica.gamsung.core.presentation
 
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.testing.TestNavHostController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.*
 import org.junit.Before
@@ -15,11 +20,14 @@ import org.junit.runner.RunWith
 class MainScreenKtTest {
     @get:Rule
     val rule: ComposeContentTestRule = createComposeRule()
+    lateinit var navController: TestNavHostController
 
     @Before
     fun setUp() {
         rule.setContent {
-            MainScreen()
+            navController = TestNavHostController(LocalContext.current)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            MainNavHost(navController = navController)
         }
     }
 
@@ -31,6 +39,16 @@ class MainScreenKtTest {
             .assertIsDisplayed()
     }
 
+    @Test
+    fun 설정_버튼을_누르면_설정_페이지로_이동한다() {
+        rule
+            .onNodeWithContentDescription("AccountCircle")
+            .performClick()
+
+        val route = navController.currentDestination?.route
+        assertEquals(route, Screen.SETTING.route)
+    }
+
     /** 메인 페이지에 글 발행 버튼이 화면에 보인다 */
     @Test
     fun publishButtonIsDisplayedOnMainPage() {
@@ -39,11 +57,32 @@ class MainScreenKtTest {
             .assertIsDisplayed()
     }
 
+
+    @Test
+    fun 글_발행_버튼을_누르면_글_발행_페이지로_이동한다() {
+        rule
+            .onNodeWithText("글 발행하러 가기")
+            .performClick()
+
+        val route = navController.currentDestination?.route
+        assertEquals(route, Screen.PUBLISH_POSTING.route)
+    }
+
     /** 메인 페이지에 발행 현황 확인 버튼이 화면에 보인다 */
     @Test
     fun checkPublishStatusButtonIsDisplayedOnMainPage() {
         rule
             .onNodeWithText("발행 현황 확인하기")
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun 발행_현황_확인_버튼을_누르면_발행_현황_페이지로_이동한다() {
+        rule
+            .onNodeWithText("발행 현황 확인하기")
+            .performClick()
+
+        val route = navController.currentDestination?.route
+        assertEquals(route, Screen.CHECK_POSTING.route)
     }
 }

--- a/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
+++ b/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
@@ -39,8 +39,9 @@ class MainScreenKtTest {
             .assertIsDisplayed()
     }
 
+    /** 설정 버튼을 누르면 설정 페이지로 이동한다 */
     @Test
-    fun 설정_버튼을_누르면_설정_페이지로_이동한다() {
+    fun navigateToSettingPageWhenSettingButtonIsClicked() {
         rule
             .onNodeWithContentDescription("AccountCircle")
             .performClick()
@@ -57,9 +58,9 @@ class MainScreenKtTest {
             .assertIsDisplayed()
     }
 
-
+    /** 글 발행 버튼을 누르면 글 발행 페이지로 이동한다 */
     @Test
-    fun 글_발행_버튼을_누르면_글_발행_페이지로_이동한다() {
+    fun navigateToPublishPostingPageWhenPublishPostingButtonIsClicked() {
         rule
             .onNodeWithText("글 발행하러 가기")
             .performClick()
@@ -76,8 +77,9 @@ class MainScreenKtTest {
             .assertIsDisplayed()
     }
 
+    /** 발행 현황 확인 버튼을 누르면 발행 현황 페이지로 이동한다 */
     @Test
-    fun 발행_현황_확인_버튼을_누르면_발행_현황_페이지로_이동한다() {
+    fun navigateToCheckPostingPageWhenCheckPostingButtonIsClicked() {
         rule
             .onNodeWithText("발행 현황 확인하기")
             .performClick()

--- a/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
+++ b/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
@@ -43,7 +43,7 @@ class MainScreenKtTest {
     @Test
     fun navigateToSettingPageWhenSettingButtonIsClicked() {
         rule
-            .onNodeWithContentDescription("AccountCircle")
+            .onNodeWithContentDescription("SettingButton")
             .performClick()
 
         val route = navController.currentDestination?.route

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -25,29 +26,34 @@ class MainActivity : ComponentActivity() {
                 ) {
                     val navController = rememberNavController()
 
-                    NavHost(navController = navController, startDestination = "main") {
-                        composable(Screen.MAIN.route) { MainScreen(navController = navController) }
-                        composable(Screen.SETTING.route) { SettingScreen() }
-                        composable(Screen.PUBLISH_POSTING.route) { PublishPostingScreen() }
-                        composable(Screen.CHECK_POSTING.route) { CheckPostingScreen() }
-                    }
+                    MainNavHost(navController)
                 }
             }
         }
     }
+}
 
-    @Composable
-    private fun SettingScreen() {
-        Text(text = "SettingScreen") // TODO 구현 시작 시 제거 및 코드 이동
+@Composable
+fun MainNavHost(navController: NavHostController) {
+    NavHost(navController = navController, startDestination = "main") {
+        composable(Screen.MAIN.route) { MainScreen(navController = navController) }
+        composable(Screen.SETTING.route) { SettingScreen() }
+        composable(Screen.PUBLISH_POSTING.route) { PublishPostingScreen() }
+        composable(Screen.CHECK_POSTING.route) { CheckPostingScreen() }
     }
+}
 
-    @Composable
-    private fun PublishPostingScreen() {
-        Text(text = "PublishPostingScreen") // TODO 구현 시작 시 제거 및 코드 이동
-    }
+@Composable
+fun SettingScreen() {
+    Text(text = "SettingScreen") // TODO 구현 시작 시 제거 및 코드 이동
+}
 
-    @Composable
-    private fun CheckPostingScreen() {
-        Text(text = "CheckPostingScreen") // TODO 구현 시작 시 제거 및 코드 이동
-    }
+@Composable
+fun PublishPostingScreen() {
+    Text(text = "PublishPostingScreen") // TODO 구현 시작 시 제거 및 코드 이동
+}
+
+@Composable
+fun CheckPostingScreen() {
+    Text(text = "CheckPostingScreen") // TODO 구현 시작 시 제거 및 코드 이동
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -6,7 +6,12 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.erica.gamsung.ui.theme.GamsungTheme
 
 class MainActivity : ComponentActivity() {
@@ -18,9 +23,31 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
-                    MainScreen()
+                    val navController = rememberNavController()
+
+                    NavHost(navController = navController, startDestination = "main") {
+                        composable("main") { MainScreen(navController = navController) }
+                        composable("setting") { SettingScreen() }
+                        composable("publishPosting") { PublishPostingScreen() }
+                        composable("checkPosting") { CheckPostingScreen() }
+                    }
                 }
             }
         }
+    }
+
+    @Composable
+    private fun SettingScreen() {
+        Text(text = "SettingScreen") // TODO 구현 시작 시 제거 및 코드 이동
+    }
+
+    @Composable
+    private fun PublishPostingScreen() {
+        Text(text = "PublishPostingScreen") // TODO 구현 시작 시 제거 및 코드 이동
+    }
+
+    @Composable
+    private fun CheckPostingScreen() {
+        Text(text = "CheckPostingScreen") // TODO 구현 시작 시 제거 및 코드 이동
     }
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -26,10 +26,10 @@ class MainActivity : ComponentActivity() {
                     val navController = rememberNavController()
 
                     NavHost(navController = navController, startDestination = "main") {
-                        composable("main") { MainScreen(navController = navController) }
-                        composable("setting") { SettingScreen() }
-                        composable("publishPosting") { PublishPostingScreen() }
-                        composable("checkPosting") { CheckPostingScreen() }
+                        composable(Screen.MAIN.route) { MainScreen(navController = navController) }
+                        composable(Screen.SETTING.route) { SettingScreen() }
+                        composable(Screen.PUBLISH_POSTING.route) { PublishPostingScreen() }
+                        composable(Screen.CHECK_POSTING.route) { CheckPostingScreen() }
                     }
                 }
             }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainScreen.kt
@@ -26,7 +26,7 @@ fun MainScreen(navController: NavHostController = rememberNavController()) {
             GsTopAppBar(
                 title = "메인 페이지",
                 hasRightIcon = true,
-                onActionsClick = { navController.navigate("setting") },
+                onActionsClick = { navController.navigate(Screen.SETTING.route) },
             )
         },
         modifier = Modifier.fillMaxSize(),
@@ -39,11 +39,11 @@ fun MainScreen(navController: NavHostController = rememberNavController()) {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
-            MainButton("글 발행하러 가기") { navController.navigate("publishPosting") }
+            MainButton("글 발행하러 가기") { navController.navigate(Screen.PUBLISH_POSTING.route) }
 
             Spacer(modifier = Modifier.height(30.dp))
 
-            MainButton("발행 현황 확인하기") { navController.navigate("checkPosting") }
+            MainButton("발행 현황 확인하기") { navController.navigate(Screen.CHECK_POSTING.route) }
         }
     }
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainScreen.kt
@@ -14,17 +14,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
 import com.erica.gamsung.core.presentation.component.GsOutlinedButton
 import com.erica.gamsung.core.presentation.component.GsTopAppBar
 
 @Composable
-fun MainScreen() {
+fun MainScreen(navController: NavHostController = rememberNavController()) {
     Scaffold(
         topBar = {
             GsTopAppBar(
                 title = "메인 페이지",
                 hasRightIcon = true,
-                onActionsClick = { TODO() },
+                onActionsClick = { navController.navigate("setting") },
             )
         },
         modifier = Modifier.fillMaxSize(),
@@ -37,17 +39,20 @@ fun MainScreen() {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
-            MainButton("글 발행하러 가기")
+            MainButton("글 발행하러 가기") { navController.navigate("publishPosting") }
 
             Spacer(modifier = Modifier.height(30.dp))
 
-            MainButton("발행 현황 확인하기")
+            MainButton("발행 현황 확인하기") { navController.navigate("checkPosting") }
         }
     }
 }
 
 @Composable
-private fun MainButton(text: String) {
+private fun MainButton(
+    text: String,
+    onClick: () -> Unit = {},
+) {
     GsOutlinedButton(
         modifier =
             Modifier
@@ -56,12 +61,12 @@ private fun MainButton(text: String) {
                 .padding(horizontal = 20.dp),
         text = text,
         fontSize = 25.sp,
-        onClick = { TODO() },
+        onClick = onClick,
     )
 }
 
 @Preview
 @Composable
 private fun MainScreenPreview() {
-    MainScreen()
+    MainScreen(navController = rememberNavController())
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
@@ -1,0 +1,10 @@
+package com.erica.gamsung.core.presentation
+
+enum class Screen(
+    val route: String,
+) {
+    MAIN("main"),
+    SETTING("setting"),
+    PUBLISH_POSTING("publishPosting"),
+    CHECK_POSTING("checkPosting"),
+}

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -204,7 +204,7 @@ fun InputTextBox(
                 modifier = innerTextModifier,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (!isFocused && text.text.isEmpty()) {
+                if (!isFocused && text == hintText) {
                     Text(hintText.text, color = Color.Gray)
                     Spacer(modifier = Modifier.weight(1f))
                 } else {

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -74,7 +74,7 @@ fun GsTextBox(
 }
 
 @Composable
-private fun TextTitle(
+fun TextTitle(
     title: String,
     isRequired: Boolean,
     description: String?,
@@ -166,7 +166,7 @@ private fun DropdownTextBox(
 }
 
 @Composable
-private fun InputTextBox(
+fun InputTextBox(
     hintText: TextFieldValue,
     modifier: Modifier,
     innerTextModifier: Modifier,

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -201,6 +202,7 @@ fun InputTextBox(
         decorationBox = { innerTextField ->
             Row(
                 modifier = innerTextModifier,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (!isFocused && text.text.isEmpty()) {
                     Text(hintText.text, color = Color.Gray)

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTopAppBar.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTopAppBar.kt
@@ -33,7 +33,7 @@ fun GsTopAppBar(
                     content = {
                         Icon(
                             imageVector = Icons.Default.ArrowBack,
-                            contentDescription = "ArrowBack",
+                            contentDescription = "PreviousButton",
                         )
                     },
                 )
@@ -47,7 +47,7 @@ fun GsTopAppBar(
                     content = {
                         Icon(
                             imageVector = Icons.Rounded.AccountCircle,
-                            contentDescription = "AccountCircle",
+                            contentDescription = "SettingButton",
                         )
                     },
                 )

--- a/app/src/main/java/com/erica/gamsung/menu/domain/Menu.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/domain/Menu.kt
@@ -1,0 +1,6 @@
+package com.erica.gamsung.menu.domain
+
+data class Menu(
+    val name: String,
+    val price: Int,
+)

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -122,12 +122,12 @@ private fun CompletedMenuItem(menu: Menu) {
                 .padding(6.dp)
                 .border(1.dp, Color.Black, RoundedCornerShape(10.dp)),
     ) {
-        TitleWithContent(
+        MenuItemContainer(
             title = "메뉴 이름",
             content = menu.name,
             modifier = Modifier.weight(1f),
         )
-        TitleWithContent(
+        MenuItemContainer(
             title = "가격",
             content = menu.price.toString(),
             modifier = Modifier.weight(1f),
@@ -148,7 +148,7 @@ private fun CompletedMenuItem(menu: Menu) {
 }
 
 @Composable
-private fun TitleWithContent(
+private fun MenuItemContainer(
     modifier: Modifier = Modifier,
     title: String,
     content: String,

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -12,13 +12,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddCircleOutline
 import androidx.compose.material.icons.filled.RemoveCircleOutline
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,6 +33,7 @@ import com.erica.gamsung.core.presentation.component.GsButton
 import com.erica.gamsung.core.presentation.component.GsTopAppBar
 import com.erica.gamsung.core.presentation.component.InputTextBox
 import com.erica.gamsung.core.presentation.component.TextTitle
+import com.erica.gamsung.menu.domain.Menu
 
 @Composable
 fun InputMenuScreen() {
@@ -65,8 +69,20 @@ fun InputMenuScreen() {
     }
 }
 
+@Suppress("MagicNumber") // TODO 기능 구현 시 제거
 @Composable
 private fun InputMenuSection() {
+    // TODO 기능 구현 시 제거
+    val menus =
+        listOf(
+            Menu("비빔밥", 12000),
+            Menu("떡볶이", 8000),
+            Menu("김치볶음밥", 9000),
+            Menu("갈비구이", 18000),
+            Menu("김치전", 13000),
+            Menu("해물파전", 15000),
+        )
+
     LazyColumn(
         modifier =
             Modifier
@@ -76,7 +92,9 @@ private fun InputMenuSection() {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Top,
     ) {
-        // TODO : 생성된 메뉴 출력
+        items(menus) { menu ->
+            CompletedMenuItem(menu)
+        }
 
         item {
             InputMenuItem()
@@ -88,6 +106,61 @@ private fun InputMenuSection() {
                 contentDescription = "메뉴 추가 아이콘",
             )
         }
+    }
+}
+
+@Composable
+private fun CompletedMenuItem(menu: Menu) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(70.dp)
+                .padding(6.dp)
+                .border(1.dp, Color.Black, RoundedCornerShape(10.dp)),
+    ) {
+        TitleWithContent(
+            title = "메뉴 이름",
+            content = menu.name,
+            modifier = Modifier.weight(1f),
+        )
+        TitleWithContent(
+            title = "가격",
+            content = menu.price.toString(),
+            modifier = Modifier.weight(1f),
+        )
+        Icon(
+            imageVector = Icons.Default.RemoveCircleOutline,
+            contentDescription = "메뉴 제거 아이콘",
+            modifier =
+                Modifier
+                    .size(20.dp)
+                    .padding(top = 5.dp, end = 5.dp),
+        )
+        IconButton(onClick = { /*TODO*/ }) {
+        }
+    }
+}
+
+@Composable
+private fun TitleWithContent(
+    modifier: Modifier = Modifier,
+    title: String,
+    content: String,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxHeight()
+                .padding(5.dp),
+        verticalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        TextTitle(
+            title = title,
+            isRequired = false,
+            description = null,
+        )
+        Text(text = content)
     }
 }
 

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -196,14 +197,7 @@ private fun InputMenuItem() {
                     .padding(5.dp)
                     .weight(1f),
         )
-        Icon(
-            imageVector = Icons.Default.RemoveCircleOutline,
-            contentDescription = "메뉴 제거 아이콘",
-            modifier =
-                Modifier
-                    .size(20.dp)
-                    .padding(top = 5.dp, end = 5.dp),
-        )
+        Spacer(modifier = Modifier.padding(10.dp))
     }
 }
 

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -1,23 +1,35 @@
 package com.erica.gamsung.menu.presentation
 
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircleOutline
+import androidx.compose.material.icons.filled.RemoveCircleOutline
 import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.erica.gamsung.core.presentation.component.GsButton
 import com.erica.gamsung.core.presentation.component.GsTopAppBar
+import com.erica.gamsung.core.presentation.component.InputTextBox
+import com.erica.gamsung.core.presentation.component.TextTitle
 
 @Composable
 fun InputMenuScreen() {
@@ -55,14 +67,88 @@ fun InputMenuScreen() {
 
 @Composable
 private fun InputMenuSection() {
-    Box(
+    LazyColumn(
         modifier =
             Modifier
                 .fillMaxSize()
                 .padding(5.dp)
                 .border(1.dp, Color.Black, RoundedCornerShape(10.dp)),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top,
     ) {
-        // TODO
+        // TODO : 생성된 메뉴 출력
+
+        item {
+            InputMenuItem()
+        }
+
+        item {
+            Icon(
+                imageVector = Icons.Default.AddCircleOutline,
+                contentDescription = "메뉴 추가 아이콘",
+            )
+        }
+    }
+}
+
+@Composable
+private fun InputMenuItem() {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(70.dp)
+                .padding(6.dp)
+                .border(1.dp, Color.Black, RoundedCornerShape(10.dp)),
+    ) {
+        TitleTextField(
+            title = "메뉴 이름",
+            hintText = "ex. 고등어 구이 정식",
+            modifier =
+                Modifier
+                    .fillMaxHeight()
+                    .padding(5.dp)
+                    .weight(1f),
+        )
+        TitleTextField(
+            title = "가격",
+            hintText = "ex. 15000",
+            modifier =
+                Modifier
+                    .fillMaxHeight()
+                    .padding(5.dp)
+                    .weight(1f),
+        )
+        Icon(
+            imageVector = Icons.Default.RemoveCircleOutline,
+            contentDescription = "메뉴 제거 아이콘",
+            modifier =
+                Modifier
+                    .size(20.dp)
+                    .padding(top = 5.dp, end = 5.dp),
+        )
+    }
+}
+
+@Composable
+private fun TitleTextField(
+    modifier: Modifier = Modifier,
+    title: String,
+    hintText: String,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        TextTitle(title = title, isRequired = true, description = null)
+        InputTextBox(
+            hintText = TextFieldValue(hintText),
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .padding(end = 10.dp),
+            innerTextModifier = Modifier.padding(start = 5.dp),
+        )
     }
 }
 

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -1,0 +1,73 @@
+package com.erica.gamsung.menu.presentation
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.erica.gamsung.core.presentation.component.GsButton
+import com.erica.gamsung.core.presentation.component.GsTopAppBar
+
+@Composable
+fun InputMenuScreen() {
+    Scaffold(
+        topBar = { GsTopAppBar(title = "메뉴 입력 (2/2)") },
+    ) { paddingValues ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+            ) {
+                InputMenuSection()
+            }
+            Divider()
+            GsButton(
+                text = "메뉴 등록하기",
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(70.dp)
+                        .padding(horizontal = 8.dp, vertical = 12.dp),
+                onClick = { TODO() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun InputMenuSection() {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(5.dp)
+                .border(1.dp, Color.Black, RoundedCornerShape(10.dp)),
+    ) {
+        // TODO
+    }
+}
+
+@Preview
+@Composable
+private fun InputMenuScreenPreview() {
+    InputMenuScreen()
+}

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -101,10 +101,12 @@ private fun InputMenuSection() {
         }
 
         item {
-            Icon(
-                imageVector = Icons.Default.AddCircleOutline,
-                contentDescription = "메뉴 추가 아이콘",
-            )
+            IconButton(onClick = { /*TODO*/ }) {
+                Icon(
+                    imageVector = Icons.Default.AddCircleOutline,
+                    contentDescription = "메뉴 추가 아이콘",
+                )
+            }
         }
     }
 }
@@ -129,15 +131,17 @@ private fun CompletedMenuItem(menu: Menu) {
             content = menu.price.toString(),
             modifier = Modifier.weight(1f),
         )
-        Icon(
-            imageVector = Icons.Default.RemoveCircleOutline,
-            contentDescription = "메뉴 제거 아이콘",
+        IconButton(
+            onClick = { /*TODO*/ },
             modifier =
                 Modifier
                     .size(20.dp)
                     .padding(top = 5.dp, end = 5.dp),
-        )
-        IconButton(onClick = { /*TODO*/ }) {
+        ) {
+            Icon(
+                imageVector = Icons.Default.RemoveCircleOutline,
+                contentDescription = "메뉴 제거 아이콘",
+            )
         }
     }
 }


### PR DESCRIPTION
## Issue
- close #10 

## Overview (Required)
- 메뉴 정보 입력 페이지 디자인을 구현한다

## Links
-

## Screenshot
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/616bc378-8306-47ca-84ba-abe18808fb30" width="300" />

## Videos
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/ac9a4a74-bdc6-4247-be49-07fa66232bc2" width="300" />

---

기존 `GsTextBox` 활용해서 구현하려고 했는데 위치 조정하려면 modifier 하나를 파라미터로 더 추가해야 하는데 
그러면 modifier가 총 3개인 상황이라 너무 많아져서 구현해놓은 `TextTitle`이랑 `InputTextBox` 활용해서 구현했어

추가적으로 피그마에선 입력하는 메뉴 공간에도 삭제 버튼 있거든?
근데 입력할땐 있으면 안 될 것 같아서 제거했어. 
이게 더 나은 것 같지??

리뷰좀용