### PR TITLE
Feature/#11 메뉴 정보 입력 페이지 기능을 구현한다.

### DIFF
--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.erica.gamsung.menu.presentation.InputMenuScreen
 import com.erica.gamsung.ui.theme.GamsungTheme
 
 class MainActivity : ComponentActivity() {
@@ -35,11 +36,12 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun MainNavHost(navController: NavHostController) {
-    NavHost(navController = navController, startDestination = "main") {
+    NavHost(navController = navController, startDestination = Screen.MAIN.route) {
         composable(Screen.MAIN.route) { MainScreen(navController = navController) }
         composable(Screen.SETTING.route) { SettingScreen() }
         composable(Screen.PUBLISH_POSTING.route) { PublishPostingScreen() }
         composable(Screen.CHECK_POSTING.route) { CheckPostingScreen() }
+        composable(Screen.INPUT_MENU.route) { InputMenuScreen(navController = navController) }
     }
 }
 

--- a/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
@@ -7,4 +7,5 @@ enum class Screen(
     SETTING("setting"),
     PUBLISH_POSTING("publishPosting"),
     CHECK_POSTING("checkPosting"),
+    INPUT_MENU("inputMenu"),
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -16,15 +16,16 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -50,7 +51,7 @@ fun GsTextBox(
     var expanded by remember { mutableStateOf(false) }
     var selectedOption by remember { mutableStateOf("") }
     Column {
-        TextTitle(title, isRequired, description)
+        TextTitle(title, isRequired, description, Modifier)
         if (options != null) {
             DropdownTextBox(
                 text,
@@ -70,9 +71,8 @@ fun GsTextBox(
             InputTextBox(
                 hintText = text.text,
                 onValueChange = { text = TextFieldValue(it) },
-                modifier = innerTextModifier,
-                innerTextModifier = modifier,
                 keyboardType = KeyboardType.Text,
+                modifier = innerTextModifier,
             )
         }
     }
@@ -83,6 +83,7 @@ fun TextTitle(
     title: String,
     isRequired: Boolean,
     description: String?,
+    modifier: Modifier = Modifier,
 ) {
     Text(
         text =
@@ -112,6 +113,8 @@ fun TextTitle(
                     description?.let { append(description) }
                 }
             },
+        style = MaterialTheme.typography.titleSmall,
+        modifier = modifier,
     )
 }
 
@@ -172,53 +175,37 @@ private fun DropdownTextBox(
 
 @Composable
 fun InputTextBox(
+    modifier: Modifier = Modifier,
     hintText: String,
     onValueChange: (String) -> Unit,
     keyboardType: KeyboardType = KeyboardType.Text,
-    modifier: Modifier,
-    innerTextModifier: Modifier,
 ) {
     var textState by remember {
-        mutableStateOf(TextFieldValue(""))
+        mutableStateOf("")
     }
-    var isFocused by remember {
-        mutableStateOf(false)
-    }
-    BasicTextField(
+    OutlinedTextField(
         value = textState,
-        onValueChange = { updatedText ->
-            textState = updatedText
-            onValueChange(updatedText.text)
+        onValueChange = {
+            textState = it
+            onValueChange(it)
         },
-        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+        placeholder = {
+            Text(
+                text = hintText,
+                color = Color.Gray,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        },
         singleLine = true,
-        modifier =
-            modifier
-                .background(Color.Transparent)
-                .border(
-                    1.dp,
-                    Color.LightGray,
-                    RoundedCornerShape(percent = 15),
-                ).onFocusChanged { focusState ->
-                    isFocused = focusState.isFocused
-                    if (isFocused && textState.text == hintText) {
-                        textState = TextFieldValue("")
-                    }
-                },
-        decorationBox = { innerTextField ->
-            Row(
-                modifier = innerTextModifier,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (!isFocused && textState.text.isBlank()) {
-                    Text(hintText, color = Color.Gray)
-                    Spacer(modifier = Modifier.weight(1f))
-                } else {
-                    innerTextField()
-                    Spacer(modifier = Modifier.weight(1f))
-                }
-            }
-        },
+        colors =
+            TextFieldDefaults.colors(
+                unfocusedContainerColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.LightGray,
+            ),
+        shape = RoundedCornerShape(percent = 15),
+        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+        textStyle = MaterialTheme.typography.bodyLarge,
+        modifier = modifier,
     )
 }
 

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.DropdownMenu
@@ -28,6 +29,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -70,6 +72,7 @@ fun GsTextBox(
                 onValueChange = { text = TextFieldValue(it) },
                 modifier = innerTextModifier,
                 innerTextModifier = modifier,
+                keyboardType = KeyboardType.Text,
             )
         }
     }
@@ -171,6 +174,7 @@ private fun DropdownTextBox(
 fun InputTextBox(
     hintText: String,
     onValueChange: (String) -> Unit,
+    keyboardType: KeyboardType = KeyboardType.Text,
     modifier: Modifier,
     innerTextModifier: Modifier,
 ) {
@@ -186,6 +190,7 @@ fun InputTextBox(
             textState = updatedText
             onValueChange(updatedText.text)
         },
+        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
         singleLine = true,
         modifier =
             modifier

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -69,10 +69,11 @@ fun GsTextBox(
             )
         } else {
             InputTextBox(
+                modifier = innerTextModifier,
                 hintText = text.text,
                 onValueChange = { text = TextFieldValue(it) },
                 keyboardType = KeyboardType.Text,
-                modifier = innerTextModifier,
+                isError = false,
             )
         }
     }
@@ -179,6 +180,7 @@ fun InputTextBox(
     hintText: String,
     onValueChange: (String) -> Unit,
     keyboardType: KeyboardType = KeyboardType.Text,
+    isError: Boolean = false,
 ) {
     var textState by remember {
         mutableStateOf("")
@@ -201,11 +203,14 @@ fun InputTextBox(
             TextFieldDefaults.colors(
                 unfocusedContainerColor = Color.Transparent,
                 unfocusedIndicatorColor = Color.LightGray,
+                focusedContainerColor = Color.Transparent,
+                errorContainerColor = Color.Transparent,
             ),
         shape = RoundedCornerShape(percent = 15),
         keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
         textStyle = MaterialTheme.typography.bodyLarge,
         modifier = modifier,
+        isError = isError,
     )
 }
 

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -44,7 +44,7 @@ fun GsTextBox(
     modifier: Modifier,
     innerTextModifier: Modifier,
 ) {
-    val text by remember { mutableStateOf(TextFieldValue(hintText)) }
+    var text by remember { mutableStateOf(TextFieldValue(hintText)) }
     var expanded by remember { mutableStateOf(false) }
     var selectedOption by remember { mutableStateOf("") }
     Column {
@@ -66,9 +66,10 @@ fun GsTextBox(
             )
         } else {
             InputTextBox(
-                text,
-                innerTextModifier,
-                modifier,
+                hintText = text.text,
+                onValueChange = { text = TextFieldValue(it) },
+                modifier = innerTextModifier,
+                innerTextModifier = modifier,
             )
         }
     }
@@ -168,20 +169,22 @@ private fun DropdownTextBox(
 
 @Composable
 fun InputTextBox(
-    hintText: TextFieldValue,
+    hintText: String,
+    onValueChange: (String) -> Unit,
     modifier: Modifier,
     innerTextModifier: Modifier,
 ) {
-    var text by remember {
-        mutableStateOf(hintText)
+    var textState by remember {
+        mutableStateOf(TextFieldValue(""))
     }
     var isFocused by remember {
         mutableStateOf(false)
     }
     BasicTextField(
-        value = text,
+        value = textState,
         onValueChange = { updatedText ->
-            text = updatedText
+            textState = updatedText
+            onValueChange(updatedText.text)
         },
         singleLine = true,
         modifier =
@@ -193,10 +196,8 @@ fun InputTextBox(
                     RoundedCornerShape(percent = 15),
                 ).onFocusChanged { focusState ->
                     isFocused = focusState.isFocused
-                    if (isFocused && text == hintText) {
-                        text = TextFieldValue("")
-                    } else if (!isFocused && text.text.isEmpty()) {
-                        text = hintText
+                    if (isFocused && textState.text == hintText) {
+                        textState = TextFieldValue("")
                     }
                 },
         decorationBox = { innerTextField ->
@@ -204,8 +205,8 @@ fun InputTextBox(
                 modifier = innerTextModifier,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (!isFocused && text == hintText) {
-                    Text(hintText.text, color = Color.Gray)
+                if (!isFocused && textState.text.isBlank()) {
+                    Text(hintText, color = Color.Gray)
                     Spacer(modifier = Modifier.weight(1f))
                 } else {
                     innerTextField()

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -88,6 +88,8 @@ fun InputMenuScreen(navController: NavHostController = rememberNavController()) 
 private fun InputMenuSection(menus: SnapshotStateList<Menu>) {
     val (name, setName) = remember { mutableStateOf("") }
     val (price, setPrice) = remember { mutableStateOf("") }
+    val isNameValid = remember { mutableStateOf(true) }
+    val isPriceValid = remember { mutableStateOf(true) }
 
     LazyColumn(
         modifier =
@@ -106,12 +108,17 @@ private fun InputMenuSection(menus: SnapshotStateList<Menu>) {
             InputMenuItem(
                 nameChanged = { setName(it) },
                 priceChanged = { setPrice(it) },
+                isNameValid = isNameValid.value,
+                isPriceValid = isPriceValid.value,
             )
         }
 
         item {
             IconButton(onClick = {
-                if (name.isNotBlank() && price.isZeroOrPrimitiveInt()) {
+                isNameValid.value = name.isNotBlank()
+                isPriceValid.value = price.isZeroOrPrimitiveInt()
+
+                if (isNameValid.value && isPriceValid.value) {
                     menus.add(Menu(name, price.toInt()))
                     setName("")
                     setPrice("")
@@ -196,6 +203,8 @@ private fun MenuItemContainer(
 private fun InputMenuItem(
     nameChanged: (String) -> Unit,
     priceChanged: (String) -> Unit,
+    isNameValid: Boolean = true,
+    isPriceValid: Boolean = true,
 ) {
     Row(
         modifier =
@@ -215,6 +224,7 @@ private fun InputMenuItem(
             hintText = "ex. 고등어 구이 정식",
             onValueChange = nameChanged,
             keyboardType = KeyboardType.Text,
+            isValid = isNameValid,
         )
         TitleTextField(
             modifier =
@@ -226,6 +236,7 @@ private fun InputMenuItem(
             hintText = "ex. 15000",
             onValueChange = priceChanged,
             keyboardType = KeyboardType.Number,
+            isValid = isPriceValid,
         )
         Spacer(modifier = Modifier.padding(10.dp))
     }
@@ -238,6 +249,7 @@ private fun TitleTextField(
     hintText: String,
     onValueChange: (String) -> Unit,
     keyboardType: KeyboardType = KeyboardType.Text,
+    isValid: Boolean = true,
 ) {
     Column(
         modifier = modifier,
@@ -248,10 +260,11 @@ private fun TitleTextField(
             description = null,
         )
         InputTextBox(
+            modifier = Modifier.padding(top = 5.dp, end = 10.dp),
             hintText = hintText,
             onValueChange = onValueChange,
             keyboardType = keyboardType,
-            modifier = Modifier.padding(top = 5.dp, end = 10.dp),
+            isError = !isValid,
         )
     }
 }

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -101,10 +101,11 @@ private fun InputMenuSection() {
 
         item {
             IconButton(onClick = {
-                // TODO 입력값 검증
-                menus.add(Menu(name, price.toInt()))
-                setName("")
-                setPrice("")
+                if (name.isNotBlank() && price.isZeroOrPrimitiveInt()) {
+                    menus.add(Menu(name, price.toInt()))
+                    setName("")
+                    setPrice("")
+                }
             }) {
                 Icon(
                     imageVector = Icons.Default.AddCircleOutline,
@@ -113,6 +114,11 @@ private fun InputMenuSection() {
             }
         }
     }
+}
+
+private fun String.isZeroOrPrimitiveInt(): Boolean {
+    val int = this.toIntOrNull() ?: return false
+    return int >= 0
 }
 
 @Composable

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -1,5 +1,6 @@
 package com.erica.gamsung.menu.presentation
 
+import android.util.Log
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -27,12 +28,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.erica.gamsung.core.presentation.Screen
 import com.erica.gamsung.core.presentation.component.GsButton
 import com.erica.gamsung.core.presentation.component.GsTopAppBar
 import com.erica.gamsung.core.presentation.component.InputTextBox
@@ -40,7 +45,7 @@ import com.erica.gamsung.core.presentation.component.TextTitle
 import com.erica.gamsung.menu.domain.Menu
 
 @Composable
-fun InputMenuScreen() {
+fun InputMenuScreen(navController: NavHostController = rememberNavController()) {
     Scaffold(
         topBar = { GsTopAppBar(title = "메뉴 입력 (2/2)") },
     ) { paddingValues ->
@@ -51,13 +56,14 @@ fun InputMenuScreen() {
                     .padding(paddingValues),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            val menus = remember { mutableStateListOf<Menu>() }
             Box(
                 modifier =
                     Modifier
                         .fillMaxWidth()
                         .weight(1f),
             ) {
-                InputMenuSection()
+                InputMenuSection(menus)
             }
             Divider()
             GsButton(
@@ -67,15 +73,19 @@ fun InputMenuScreen() {
                         .fillMaxWidth()
                         .height(70.dp)
                         .padding(horizontal = 8.dp, vertical = 12.dp),
-                onClick = { TODO() },
+                onClick = {
+                    // TODO 서버로 메뉴 전송
+                    Log.d("InputMenuScreen", "서버로 전송할 메뉴 목록\n ${menus.toList().joinToString("\n")}")
+
+                    navController.navigate(Screen.MAIN.route)
+                },
             )
         }
     }
 }
 
 @Composable
-private fun InputMenuSection() {
-    val menus = remember { mutableStateListOf<Menu>() }
+private fun InputMenuSection(menus: SnapshotStateList<Menu>) {
     val (name, setName) = remember { mutableStateOf("") }
     val (price, setPrice) = remember { mutableStateOf("") }
 

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.erica.gamsung.core.presentation.component.GsButton
@@ -196,6 +197,7 @@ private fun InputMenuItem(
             title = "메뉴 이름",
             hintText = "ex. 고등어 구이 정식",
             onValueChange = nameChanged,
+            keyboardType = KeyboardType.Text,
         )
         TitleTextField(
             modifier =
@@ -206,6 +208,7 @@ private fun InputMenuItem(
             title = "가격",
             hintText = "ex. 15000",
             onValueChange = priceChanged,
+            keyboardType = KeyboardType.Number,
         )
         Spacer(modifier = Modifier.padding(10.dp))
     }
@@ -217,6 +220,7 @@ private fun TitleTextField(
     title: String,
     hintText: String,
     onValueChange: (String) -> Unit,
+    keyboardType: KeyboardType = KeyboardType.Text,
 ) {
     Column(
         modifier = modifier,
@@ -231,6 +235,7 @@ private fun TitleTextField(
                     .weight(1f)
                     .padding(end = 10.dp),
             innerTextModifier = Modifier.padding(start = 5.dp),
+            keyboardType = keyboardType,
         )
     }
 }

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -25,11 +25,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.erica.gamsung.core.presentation.component.GsButton
@@ -72,20 +72,11 @@ fun InputMenuScreen() {
     }
 }
 
-@Suppress("MagicNumber") // TODO 기능 구현 시 제거
 @Composable
 private fun InputMenuSection() {
-    val menus =
-        remember {
-            mutableStateListOf(
-                Menu("비빔밥", 12000),
-                Menu("떡볶이", 8000),
-                Menu("김치볶음밥", 9000),
-                Menu("갈비구이", 18000),
-                Menu("김치전", 13000),
-                Menu("해물파전", 15000),
-            )
-        }
+    val menus = remember { mutableStateListOf<Menu>() }
+    val (name, setName) = remember { mutableStateOf("") }
+    val (price, setPrice) = remember { mutableStateOf("") }
 
     LazyColumn(
         modifier =
@@ -101,11 +92,19 @@ private fun InputMenuSection() {
         }
 
         item {
-            InputMenuItem()
+            InputMenuItem(
+                nameChanged = { setName(it) },
+                priceChanged = { setPrice(it) },
+            )
         }
 
         item {
-            IconButton(onClick = { /*TODO*/ }) {
+            IconButton(onClick = {
+                // TODO 입력값 검증
+                menus.add(Menu(name, price.toInt()))
+                setName("")
+                setPrice("")
+            }) {
                 Icon(
                     imageVector = Icons.Default.AddCircleOutline,
                     contentDescription = "메뉴 추가 아이콘",
@@ -176,7 +175,10 @@ private fun MenuItemContainer(
 }
 
 @Composable
-private fun InputMenuItem() {
+private fun InputMenuItem(
+    nameChanged: (String) -> Unit,
+    priceChanged: (String) -> Unit,
+) {
     Row(
         modifier =
             Modifier
@@ -186,22 +188,24 @@ private fun InputMenuItem() {
                 .border(1.dp, Color.Black, RoundedCornerShape(10.dp)),
     ) {
         TitleTextField(
+            modifier =
+                Modifier
+                    .fillMaxHeight()
+                    .padding(5.dp)
+                    .weight(1f),
             title = "메뉴 이름",
             hintText = "ex. 고등어 구이 정식",
-            modifier =
-                Modifier
-                    .fillMaxHeight()
-                    .padding(5.dp)
-                    .weight(1f),
+            onValueChange = nameChanged,
         )
         TitleTextField(
-            title = "가격",
-            hintText = "ex. 15000",
             modifier =
                 Modifier
                     .fillMaxHeight()
                     .padding(5.dp)
                     .weight(1f),
+            title = "가격",
+            hintText = "ex. 15000",
+            onValueChange = priceChanged,
         )
         Spacer(modifier = Modifier.padding(10.dp))
     }
@@ -212,6 +216,7 @@ private fun TitleTextField(
     modifier: Modifier = Modifier,
     title: String,
     hintText: String,
+    onValueChange: (String) -> Unit,
 ) {
     Column(
         modifier = modifier,
@@ -219,7 +224,8 @@ private fun TitleTextField(
     ) {
         TextTitle(title = title, isRequired = true, description = null)
         InputTextBox(
-            hintText = TextFieldValue(hintText),
+            hintText = hintText,
+            onValueChange = onValueChange,
             modifier =
                 Modifier
                     .weight(1f)

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -186,6 +186,7 @@ private fun MenuItemContainer(
             title = title,
             isRequired = false,
             description = null,
+            modifier = Modifier,
         )
         Text(text = content)
     }
@@ -200,7 +201,7 @@ private fun InputMenuItem(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(70.dp)
+                .height(100.dp)
                 .padding(6.dp)
                 .border(1.dp, Color.Black, RoundedCornerShape(10.dp)),
     ) {
@@ -240,18 +241,17 @@ private fun TitleTextField(
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.SpaceEvenly,
     ) {
-        TextTitle(title = title, isRequired = true, description = null)
+        TextTitle(
+            title = title,
+            isRequired = true,
+            description = null,
+        )
         InputTextBox(
             hintText = hintText,
             onValueChange = onValueChange,
-            modifier =
-                Modifier
-                    .weight(1f)
-                    .padding(end = 10.dp),
-            innerTextModifier = Modifier.padding(start = 5.dp),
             keyboardType = keyboardType,
+            modifier = Modifier.padding(top = 5.dp, end = 10.dp),
         )
     }
 }

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddCircleOutline
@@ -24,6 +24,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -73,16 +75,17 @@ fun InputMenuScreen() {
 @Suppress("MagicNumber") // TODO 기능 구현 시 제거
 @Composable
 private fun InputMenuSection() {
-    // TODO 기능 구현 시 제거
     val menus =
-        listOf(
-            Menu("비빔밥", 12000),
-            Menu("떡볶이", 8000),
-            Menu("김치볶음밥", 9000),
-            Menu("갈비구이", 18000),
-            Menu("김치전", 13000),
-            Menu("해물파전", 15000),
-        )
+        remember {
+            mutableStateListOf(
+                Menu("비빔밥", 12000),
+                Menu("떡볶이", 8000),
+                Menu("김치볶음밥", 9000),
+                Menu("갈비구이", 18000),
+                Menu("김치전", 13000),
+                Menu("해물파전", 15000),
+            )
+        }
 
     LazyColumn(
         modifier =
@@ -93,8 +96,8 @@ private fun InputMenuSection() {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Top,
     ) {
-        items(menus) { menu ->
-            CompletedMenuItem(menu)
+        itemsIndexed(menus) { index, menu ->
+            CompletedMenuItem(menu) { menus.removeAt(index) }
         }
 
         item {
@@ -113,7 +116,10 @@ private fun InputMenuSection() {
 }
 
 @Composable
-private fun CompletedMenuItem(menu: Menu) {
+private fun CompletedMenuItem(
+    menu: Menu,
+    onClick: () -> Unit,
+) {
     Row(
         modifier =
             Modifier
@@ -133,7 +139,7 @@ private fun CompletedMenuItem(menu: Menu) {
             modifier = Modifier.weight(1f),
         )
         IconButton(
-            onClick = { /*TODO*/ },
+            onClick = onClick,
             modifier =
                 Modifier
                     .size(20.dp)

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -57,13 +58,16 @@ fun InputMenuScreen(navController: NavHostController = rememberNavController()) 
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             val menus = remember { mutableStateListOf<Menu>() }
+            val isNameValid = remember { mutableStateOf(true) }
+            val isPriceValid = remember { mutableStateOf(true) }
+
             Box(
                 modifier =
                     Modifier
                         .fillMaxWidth()
                         .weight(1f),
             ) {
-                InputMenuSection(menus)
+                InputMenuSection(menus, isNameValid, isPriceValid)
             }
             Divider()
             GsButton(
@@ -77,7 +81,12 @@ fun InputMenuScreen(navController: NavHostController = rememberNavController()) 
                     // TODO 서버로 메뉴 전송
                     Log.d("InputMenuScreen", "서버로 전송할 메뉴 목록\n ${menus.toList().joinToString("\n")}")
 
-                    navController.navigate(Screen.MAIN.route)
+                    if (menus.isEmpty()) {
+                        isNameValid.value = false
+                        isPriceValid.value = false
+                    } else {
+                        navController.navigate(Screen.MAIN.route)
+                    }
                 },
             )
         }
@@ -85,11 +94,13 @@ fun InputMenuScreen(navController: NavHostController = rememberNavController()) 
 }
 
 @Composable
-private fun InputMenuSection(menus: SnapshotStateList<Menu>) {
+private fun InputMenuSection(
+    menus: SnapshotStateList<Menu>,
+    isNameValid: MutableState<Boolean>,
+    isPriceValid: MutableState<Boolean>,
+) {
     val (name, setName) = remember { mutableStateOf("") }
     val (price, setPrice) = remember { mutableStateOf("") }
-    val isNameValid = remember { mutableStateOf(true) }
-    val isPriceValid = remember { mutableStateOf(true) }
 
     LazyColumn(
         modifier =


### PR DESCRIPTION
## Issue
- close #11 

## Overview (Required)
- 메뉴 정보 입력 페이지 기능을 구현한다.
  - 메뉴 추가
  - 메뉴 삭제
  - 메인 페이지로 네비게이션
  - 메뉴 이름 검증
  - 가격 검증
  - 메뉴 개수가 최소 1개 이상인지 검증
- 서버로 메뉴 전송 (미구현)

## Links
-

## Screenshot
### 검증
![GIFMaker_me (2)](https://github.com/ERICA-gamsung/android/assets/55042337/c928b15b-4035-4561-882a-d7b70bd7aca6)
### 추가, 삭제, 네비게이션
![GIFMaker_me (3)](https://github.com/ERICA-gamsung/android/assets/55042337/275af81d-3c65-49ea-b84b-0a2b3a4a63b2)

--- 

아까 말한대로 `OutlinedTextField` 활용해서 기존 `InputTextBox` 내부 구현 변경했어.
근데 `OutlinedTextField`는 최소한의 높이를 충족 못시키면 글자가 덜 보여서 좀 높이가 높아져버림;;
서버로 메뉴 전송하는 것은 서버측 API 구현 완료된 시점에 구현할게.

우선 `InputMenuScreen`에 모든 기능들이 다 있고 리팩터링해야 하는데 추가하거나 변경될 코드가 많아질 것 같아서
MVVM 구조로 리팩터링 하는 이슈 만들어서 리팩터링해볼게.

확인해보고 리뷰점