### PR TITLE
Refactor/#29 메뉴 입력 페이지 구현을 MVVM 패턴으로 리팩터링한다

### DIFF
--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.erica.gamsung.menu.presentation.InputMenuScreen
+import com.erica.gamsung.menu.presentation.InputMenuViewModel
 import com.erica.gamsung.ui.theme.GamsungTheme
 
 class MainActivity : ComponentActivity() {
@@ -41,7 +42,9 @@ fun MainNavHost(navController: NavHostController) {
         composable(Screen.SETTING.route) { SettingScreen() }
         composable(Screen.PUBLISH_POSTING.route) { PublishPostingScreen() }
         composable(Screen.CHECK_POSTING.route) { CheckPostingScreen() }
-        composable(Screen.INPUT_MENU.route) { InputMenuScreen(navController = navController) }
+        composable(Screen.INPUT_MENU.route) {
+            InputMenuScreen(navController = navController, inputMenuViewModel = InputMenuViewModel())
+        }
     }
 }
 

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.erica.gamsung.menu.presentation.InputMenuScreen
 import com.erica.gamsung.ui.theme.GamsungTheme
 
 class MainActivity : ComponentActivity() {
@@ -35,11 +36,12 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun MainNavHost(navController: NavHostController) {
-    NavHost(navController = navController, startDestination = "main") {
+    NavHost(navController = navController, startDestination = Screen.MAIN.route) {
         composable(Screen.MAIN.route) { MainScreen(navController = navController) }
         composable(Screen.SETTING.route) { SettingScreen() }
         composable(Screen.PUBLISH_POSTING.route) { PublishPostingScreen() }
         composable(Screen.CHECK_POSTING.route) { CheckPostingScreen() }
+        composable(Screen.INPUT_MENU.route) { InputMenuScreen(navController = navController) }
     }
 }
 

--- a/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
@@ -7,4 +7,5 @@ enum class Screen(
     SETTING("setting"),
     PUBLISH_POSTING("publishPosting"),
     CHECK_POSTING("checkPosting"),
+    INPUT_MENU("inputMenu"),
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -16,15 +16,16 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -50,7 +51,7 @@ fun GsTextBox(
     var expanded by remember { mutableStateOf(false) }
     var selectedOption by remember { mutableStateOf("") }
     Column {
-        TextTitle(title, isRequired, description)
+        TextTitle(title, isRequired, description, Modifier)
         if (options != null) {
             DropdownTextBox(
                 text,
@@ -70,9 +71,8 @@ fun GsTextBox(
             InputTextBox(
                 hintText = text.text,
                 onValueChange = { text = TextFieldValue(it) },
-                modifier = innerTextModifier,
-                innerTextModifier = modifier,
                 keyboardType = KeyboardType.Text,
+                modifier = innerTextModifier,
             )
         }
     }
@@ -83,6 +83,7 @@ fun TextTitle(
     title: String,
     isRequired: Boolean,
     description: String?,
+    modifier: Modifier = Modifier,
 ) {
     Text(
         text =
@@ -112,6 +113,8 @@ fun TextTitle(
                     description?.let { append(description) }
                 }
             },
+        style = MaterialTheme.typography.titleSmall,
+        modifier = modifier,
     )
 }
 
@@ -172,53 +175,37 @@ private fun DropdownTextBox(
 
 @Composable
 fun InputTextBox(
+    modifier: Modifier = Modifier,
     hintText: String,
     onValueChange: (String) -> Unit,
     keyboardType: KeyboardType = KeyboardType.Text,
-    modifier: Modifier,
-    innerTextModifier: Modifier,
 ) {
     var textState by remember {
-        mutableStateOf(TextFieldValue(""))
+        mutableStateOf("")
     }
-    var isFocused by remember {
-        mutableStateOf(false)
-    }
-    BasicTextField(
+    OutlinedTextField(
         value = textState,
-        onValueChange = { updatedText ->
-            textState = updatedText
-            onValueChange(updatedText.text)
+        onValueChange = {
+            textState = it
+            onValueChange(it)
         },
-        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+        placeholder = {
+            Text(
+                text = hintText,
+                color = Color.Gray,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        },
         singleLine = true,
-        modifier =
-            modifier
-                .background(Color.Transparent)
-                .border(
-                    1.dp,
-                    Color.LightGray,
-                    RoundedCornerShape(percent = 15),
-                ).onFocusChanged { focusState ->
-                    isFocused = focusState.isFocused
-                    if (isFocused && textState.text == hintText) {
-                        textState = TextFieldValue("")
-                    }
-                },
-        decorationBox = { innerTextField ->
-            Row(
-                modifier = innerTextModifier,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (!isFocused && textState.text.isBlank()) {
-                    Text(hintText, color = Color.Gray)
-                    Spacer(modifier = Modifier.weight(1f))
-                } else {
-                    innerTextField()
-                    Spacer(modifier = Modifier.weight(1f))
-                }
-            }
-        },
+        colors =
+            TextFieldDefaults.colors(
+                unfocusedContainerColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.LightGray,
+            ),
+        shape = RoundedCornerShape(percent = 15),
+        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+        textStyle = MaterialTheme.typography.bodyLarge,
+        modifier = modifier,
     )
 }
 

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.DropdownMenu
@@ -28,6 +29,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -70,6 +72,7 @@ fun GsTextBox(
                 onValueChange = { text = TextFieldValue(it) },
                 modifier = innerTextModifier,
                 innerTextModifier = modifier,
+                keyboardType = KeyboardType.Text,
             )
         }
     }
@@ -171,6 +174,7 @@ private fun DropdownTextBox(
 fun InputTextBox(
     hintText: String,
     onValueChange: (String) -> Unit,
+    keyboardType: KeyboardType = KeyboardType.Text,
     modifier: Modifier,
     innerTextModifier: Modifier,
 ) {
@@ -186,6 +190,7 @@ fun InputTextBox(
             textState = updatedText
             onValueChange(updatedText.text)
         },
+        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
         singleLine = true,
         modifier =
             modifier

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -69,10 +69,11 @@ fun GsTextBox(
             )
         } else {
             InputTextBox(
+                modifier = innerTextModifier,
                 hintText = text.text,
                 onValueChange = { text = TextFieldValue(it) },
                 keyboardType = KeyboardType.Text,
-                modifier = innerTextModifier,
+                isError = false,
             )
         }
     }
@@ -179,6 +180,7 @@ fun InputTextBox(
     hintText: String,
     onValueChange: (String) -> Unit,
     keyboardType: KeyboardType = KeyboardType.Text,
+    isError: Boolean = false,
 ) {
     var textState by remember {
         mutableStateOf("")
@@ -201,11 +203,14 @@ fun InputTextBox(
             TextFieldDefaults.colors(
                 unfocusedContainerColor = Color.Transparent,
                 unfocusedIndicatorColor = Color.LightGray,
+                focusedContainerColor = Color.Transparent,
+                errorContainerColor = Color.Transparent,
             ),
         shape = RoundedCornerShape(percent = 15),
         keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
         textStyle = MaterialTheme.typography.bodyLarge,
         modifier = modifier,
+        isError = isError,
     )
 }
 

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -44,7 +44,7 @@ fun GsTextBox(
     modifier: Modifier,
     innerTextModifier: Modifier,
 ) {
-    val text by remember { mutableStateOf(TextFieldValue(hintText)) }
+    var text by remember { mutableStateOf(TextFieldValue(hintText)) }
     var expanded by remember { mutableStateOf(false) }
     var selectedOption by remember { mutableStateOf("") }
     Column {
@@ -66,9 +66,10 @@ fun GsTextBox(
             )
         } else {
             InputTextBox(
-                text,
-                innerTextModifier,
-                modifier,
+                hintText = text.text,
+                onValueChange = { text = TextFieldValue(it) },
+                modifier = innerTextModifier,
+                innerTextModifier = modifier,
             )
         }
     }
@@ -168,20 +169,22 @@ private fun DropdownTextBox(
 
 @Composable
 fun InputTextBox(
-    hintText: TextFieldValue,
+    hintText: String,
+    onValueChange: (String) -> Unit,
     modifier: Modifier,
     innerTextModifier: Modifier,
 ) {
-    var text by remember {
-        mutableStateOf(hintText)
+    var textState by remember {
+        mutableStateOf(TextFieldValue(""))
     }
     var isFocused by remember {
         mutableStateOf(false)
     }
     BasicTextField(
-        value = text,
+        value = textState,
         onValueChange = { updatedText ->
-            text = updatedText
+            textState = updatedText
+            onValueChange(updatedText.text)
         },
         singleLine = true,
         modifier =
@@ -193,10 +196,8 @@ fun InputTextBox(
                     RoundedCornerShape(percent = 15),
                 ).onFocusChanged { focusState ->
                     isFocused = focusState.isFocused
-                    if (isFocused && text == hintText) {
-                        text = TextFieldValue("")
-                    } else if (!isFocused && text.text.isEmpty()) {
-                        text = hintText
+                    if (isFocused && textState.text == hintText) {
+                        textState = TextFieldValue("")
                     }
                 },
         decorationBox = { innerTextField ->
@@ -204,8 +205,8 @@ fun InputTextBox(
                 modifier = innerTextModifier,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (!isFocused && text == hintText) {
-                    Text(hintText.text, color = Color.Gray)
+                if (!isFocused && textState.text.isBlank()) {
+                    Text(hintText, color = Color.Gray)
                     Spacer(modifier = Modifier.weight(1f))
                 } else {
                     innerTextField()

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -88,6 +88,8 @@ fun InputMenuScreen(navController: NavHostController = rememberNavController()) 
 private fun InputMenuSection(menus: SnapshotStateList<Menu>) {
     val (name, setName) = remember { mutableStateOf("") }
     val (price, setPrice) = remember { mutableStateOf("") }
+    val isNameValid = remember { mutableStateOf(true) }
+    val isPriceValid = remember { mutableStateOf(true) }
 
     LazyColumn(
         modifier =
@@ -106,12 +108,17 @@ private fun InputMenuSection(menus: SnapshotStateList<Menu>) {
             InputMenuItem(
                 nameChanged = { setName(it) },
                 priceChanged = { setPrice(it) },
+                isNameValid = isNameValid.value,
+                isPriceValid = isPriceValid.value,
             )
         }
 
         item {
             IconButton(onClick = {
-                if (name.isNotBlank() && price.isZeroOrPrimitiveInt()) {
+                isNameValid.value = name.isNotBlank()
+                isPriceValid.value = price.isZeroOrPrimitiveInt()
+
+                if (isNameValid.value && isPriceValid.value) {
                     menus.add(Menu(name, price.toInt()))
                     setName("")
                     setPrice("")
@@ -196,6 +203,8 @@ private fun MenuItemContainer(
 private fun InputMenuItem(
     nameChanged: (String) -> Unit,
     priceChanged: (String) -> Unit,
+    isNameValid: Boolean = true,
+    isPriceValid: Boolean = true,
 ) {
     Row(
         modifier =
@@ -215,6 +224,7 @@ private fun InputMenuItem(
             hintText = "ex. 고등어 구이 정식",
             onValueChange = nameChanged,
             keyboardType = KeyboardType.Text,
+            isValid = isNameValid,
         )
         TitleTextField(
             modifier =
@@ -226,6 +236,7 @@ private fun InputMenuItem(
             hintText = "ex. 15000",
             onValueChange = priceChanged,
             keyboardType = KeyboardType.Number,
+            isValid = isPriceValid,
         )
         Spacer(modifier = Modifier.padding(10.dp))
     }
@@ -238,6 +249,7 @@ private fun TitleTextField(
     hintText: String,
     onValueChange: (String) -> Unit,
     keyboardType: KeyboardType = KeyboardType.Text,
+    isValid: Boolean = true,
 ) {
     Column(
         modifier = modifier,
@@ -248,10 +260,11 @@ private fun TitleTextField(
             description = null,
         )
         InputTextBox(
+            modifier = Modifier.padding(top = 5.dp, end = 10.dp),
             hintText = hintText,
             onValueChange = onValueChange,
             keyboardType = keyboardType,
-            modifier = Modifier.padding(top = 5.dp, end = 10.dp),
+            isError = !isValid,
         )
     }
 }

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -101,10 +101,11 @@ private fun InputMenuSection() {
 
         item {
             IconButton(onClick = {
-                // TODO 입력값 검증
-                menus.add(Menu(name, price.toInt()))
-                setName("")
-                setPrice("")
+                if (name.isNotBlank() && price.isZeroOrPrimitiveInt()) {
+                    menus.add(Menu(name, price.toInt()))
+                    setName("")
+                    setPrice("")
+                }
             }) {
                 Icon(
                     imageVector = Icons.Default.AddCircleOutline,
@@ -113,6 +114,11 @@ private fun InputMenuSection() {
             }
         }
     }
+}
+
+private fun String.isZeroOrPrimitiveInt(): Boolean {
+    val int = this.toIntOrNull() ?: return false
+    return int >= 0
 }
 
 @Composable

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -1,5 +1,6 @@
 package com.erica.gamsung.menu.presentation
 
+import android.util.Log
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -27,12 +28,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.erica.gamsung.core.presentation.Screen
 import com.erica.gamsung.core.presentation.component.GsButton
 import com.erica.gamsung.core.presentation.component.GsTopAppBar
 import com.erica.gamsung.core.presentation.component.InputTextBox
@@ -40,7 +45,7 @@ import com.erica.gamsung.core.presentation.component.TextTitle
 import com.erica.gamsung.menu.domain.Menu
 
 @Composable
-fun InputMenuScreen() {
+fun InputMenuScreen(navController: NavHostController = rememberNavController()) {
     Scaffold(
         topBar = { GsTopAppBar(title = "메뉴 입력 (2/2)") },
     ) { paddingValues ->
@@ -51,13 +56,14 @@ fun InputMenuScreen() {
                     .padding(paddingValues),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            val menus = remember { mutableStateListOf<Menu>() }
             Box(
                 modifier =
                     Modifier
                         .fillMaxWidth()
                         .weight(1f),
             ) {
-                InputMenuSection()
+                InputMenuSection(menus)
             }
             Divider()
             GsButton(
@@ -67,15 +73,19 @@ fun InputMenuScreen() {
                         .fillMaxWidth()
                         .height(70.dp)
                         .padding(horizontal = 8.dp, vertical = 12.dp),
-                onClick = { TODO() },
+                onClick = {
+                    // TODO 서버로 메뉴 전송
+                    Log.d("InputMenuScreen", "서버로 전송할 메뉴 목록\n ${menus.toList().joinToString("\n")}")
+
+                    navController.navigate(Screen.MAIN.route)
+                },
             )
         }
     }
 }
 
 @Composable
-private fun InputMenuSection() {
-    val menus = remember { mutableStateListOf<Menu>() }
+private fun InputMenuSection(menus: SnapshotStateList<Menu>) {
     val (name, setName) = remember { mutableStateOf("") }
     val (price, setPrice) = remember { mutableStateOf("") }
 

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.erica.gamsung.core.presentation.component.GsButton
@@ -196,6 +197,7 @@ private fun InputMenuItem(
             title = "메뉴 이름",
             hintText = "ex. 고등어 구이 정식",
             onValueChange = nameChanged,
+            keyboardType = KeyboardType.Text,
         )
         TitleTextField(
             modifier =
@@ -206,6 +208,7 @@ private fun InputMenuItem(
             title = "가격",
             hintText = "ex. 15000",
             onValueChange = priceChanged,
+            keyboardType = KeyboardType.Number,
         )
         Spacer(modifier = Modifier.padding(10.dp))
     }
@@ -217,6 +220,7 @@ private fun TitleTextField(
     title: String,
     hintText: String,
     onValueChange: (String) -> Unit,
+    keyboardType: KeyboardType = KeyboardType.Text,
 ) {
     Column(
         modifier = modifier,
@@ -231,6 +235,7 @@ private fun TitleTextField(
                     .weight(1f)
                     .padding(end = 10.dp),
             innerTextModifier = Modifier.padding(start = 5.dp),
+            keyboardType = keyboardType,
         )
     }
 }

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -25,11 +25,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.erica.gamsung.core.presentation.component.GsButton
@@ -72,20 +72,11 @@ fun InputMenuScreen() {
     }
 }
 
-@Suppress("MagicNumber") // TODO 기능 구현 시 제거
 @Composable
 private fun InputMenuSection() {
-    val menus =
-        remember {
-            mutableStateListOf(
-                Menu("비빔밥", 12000),
-                Menu("떡볶이", 8000),
-                Menu("김치볶음밥", 9000),
-                Menu("갈비구이", 18000),
-                Menu("김치전", 13000),
-                Menu("해물파전", 15000),
-            )
-        }
+    val menus = remember { mutableStateListOf<Menu>() }
+    val (name, setName) = remember { mutableStateOf("") }
+    val (price, setPrice) = remember { mutableStateOf("") }
 
     LazyColumn(
         modifier =
@@ -101,11 +92,19 @@ private fun InputMenuSection() {
         }
 
         item {
-            InputMenuItem()
+            InputMenuItem(
+                nameChanged = { setName(it) },
+                priceChanged = { setPrice(it) },
+            )
         }
 
         item {
-            IconButton(onClick = { /*TODO*/ }) {
+            IconButton(onClick = {
+                // TODO 입력값 검증
+                menus.add(Menu(name, price.toInt()))
+                setName("")
+                setPrice("")
+            }) {
                 Icon(
                     imageVector = Icons.Default.AddCircleOutline,
                     contentDescription = "메뉴 추가 아이콘",
@@ -176,7 +175,10 @@ private fun MenuItemContainer(
 }
 
 @Composable
-private fun InputMenuItem() {
+private fun InputMenuItem(
+    nameChanged: (String) -> Unit,
+    priceChanged: (String) -> Unit,
+) {
     Row(
         modifier =
             Modifier
@@ -186,22 +188,24 @@ private fun InputMenuItem() {
                 .border(1.dp, Color.Black, RoundedCornerShape(10.dp)),
     ) {
         TitleTextField(
+            modifier =
+                Modifier
+                    .fillMaxHeight()
+                    .padding(5.dp)
+                    .weight(1f),
             title = "메뉴 이름",
             hintText = "ex. 고등어 구이 정식",
-            modifier =
-                Modifier
-                    .fillMaxHeight()
-                    .padding(5.dp)
-                    .weight(1f),
+            onValueChange = nameChanged,
         )
         TitleTextField(
-            title = "가격",
-            hintText = "ex. 15000",
             modifier =
                 Modifier
                     .fillMaxHeight()
                     .padding(5.dp)
                     .weight(1f),
+            title = "가격",
+            hintText = "ex. 15000",
+            onValueChange = priceChanged,
         )
         Spacer(modifier = Modifier.padding(10.dp))
     }
@@ -212,6 +216,7 @@ private fun TitleTextField(
     modifier: Modifier = Modifier,
     title: String,
     hintText: String,
+    onValueChange: (String) -> Unit,
 ) {
     Column(
         modifier = modifier,
@@ -219,7 +224,8 @@ private fun TitleTextField(
     ) {
         TextTitle(title = title, isRequired = true, description = null)
         InputTextBox(
-            hintText = TextFieldValue(hintText),
+            hintText = hintText,
+            onValueChange = onValueChange,
             modifier =
                 Modifier
                     .weight(1f)

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -1,6 +1,5 @@
 package com.erica.gamsung.menu.presentation
 
-import android.util.Log
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -27,8 +26,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -52,6 +49,7 @@ fun InputMenuScreen(
 ) {
     val menus by inputMenuViewModel.menusState.collectAsState()
     val inputMenuState by inputMenuViewModel.inputMenuState.collectAsState()
+    val shouldNavigate by inputMenuViewModel.shouldNavigateState.collectAsState()
 
     Scaffold(
         topBar = { GsTopAppBar(title = "메뉴 입력 (2/2)") },
@@ -63,9 +61,6 @@ fun InputMenuScreen(
                     .padding(paddingValues),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            val isNameValid = remember { mutableStateOf(true) }
-            val isPriceValid = remember { mutableStateOf(true) }
-
             Box(
                 modifier =
                     Modifier
@@ -83,13 +78,8 @@ fun InputMenuScreen(
                         .height(70.dp)
                         .padding(horizontal = 8.dp, vertical = 12.dp),
                 onClick = {
-                    // TODO 서버로 메뉴 전송
-                    Log.d("InputMenuScreen", "서버로 전송할 메뉴 목록\n ${menus.toList().joinToString("\n")}")
-
-                    if (menus.isEmpty()) {
-                        isNameValid.value = false
-                        isPriceValid.value = false
-                    } else {
+                    inputMenuViewModel.onEvent(InputMenuUiEvent.SendMenus)
+                    if (shouldNavigate) {
                         navController.navigate(Screen.MAIN.route)
                     }
                 },

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -186,6 +186,7 @@ private fun MenuItemContainer(
             title = title,
             isRequired = false,
             description = null,
+            modifier = Modifier,
         )
         Text(text = content)
     }
@@ -200,7 +201,7 @@ private fun InputMenuItem(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(70.dp)
+                .height(100.dp)
                 .padding(6.dp)
                 .border(1.dp, Color.Black, RoundedCornerShape(10.dp)),
     ) {
@@ -240,18 +241,17 @@ private fun TitleTextField(
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.SpaceEvenly,
     ) {
-        TextTitle(title = title, isRequired = true, description = null)
+        TextTitle(
+            title = title,
+            isRequired = true,
+            description = null,
+        )
         InputTextBox(
             hintText = hintText,
             onValueChange = onValueChange,
-            modifier =
-                Modifier
-                    .weight(1f)
-                    .padding(end = 10.dp),
-            innerTextModifier = Modifier.padding(start = 5.dp),
             keyboardType = keyboardType,
+            modifier = Modifier.padding(top = 5.dp, end = 10.dp),
         )
     }
 }

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddCircleOutline
@@ -24,6 +24,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -73,16 +75,17 @@ fun InputMenuScreen() {
 @Suppress("MagicNumber") // TODO 기능 구현 시 제거
 @Composable
 private fun InputMenuSection() {
-    // TODO 기능 구현 시 제거
     val menus =
-        listOf(
-            Menu("비빔밥", 12000),
-            Menu("떡볶이", 8000),
-            Menu("김치볶음밥", 9000),
-            Menu("갈비구이", 18000),
-            Menu("김치전", 13000),
-            Menu("해물파전", 15000),
-        )
+        remember {
+            mutableStateListOf(
+                Menu("비빔밥", 12000),
+                Menu("떡볶이", 8000),
+                Menu("김치볶음밥", 9000),
+                Menu("갈비구이", 18000),
+                Menu("김치전", 13000),
+                Menu("해물파전", 15000),
+            )
+        }
 
     LazyColumn(
         modifier =
@@ -93,8 +96,8 @@ private fun InputMenuSection() {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Top,
     ) {
-        items(menus) { menu ->
-            CompletedMenuItem(menu)
+        itemsIndexed(menus) { index, menu ->
+            CompletedMenuItem(menu) { menus.removeAt(index) }
         }
 
         item {
@@ -113,7 +116,10 @@ private fun InputMenuSection() {
 }
 
 @Composable
-private fun CompletedMenuItem(menu: Menu) {
+private fun CompletedMenuItem(
+    menu: Menu,
+    onClick: () -> Unit,
+) {
     Row(
         modifier =
             Modifier
@@ -133,7 +139,7 @@ private fun CompletedMenuItem(menu: Menu) {
             modifier = Modifier.weight(1f),
         )
         IconButton(
-            onClick = { /*TODO*/ },
+            onClick = onClick,
             modifier =
                 Modifier
                     .size(20.dp)

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -109,8 +109,6 @@ private fun InputMenuSection(
     inputMenuState: InputMenuState,
     inputMenuViewModel: InputMenuViewModel,
 ) {
-    val (price, setPrice) = remember { mutableStateOf("") }
-
     LazyColumn(
         modifier =
             Modifier
@@ -129,7 +127,9 @@ private fun InputMenuSection(
                 nameChanged = {
                     inputMenuViewModel.onEvent(InputMenuUiEvent.NameChanged(it))
                 },
-                priceChanged = { setPrice(it) },
+                priceChanged = {
+                    inputMenuViewModel.onEvent(InputMenuUiEvent.PriceChanged(it))
+                },
                 isNameValid = isNameValid.value,
                 isPriceValid = isPriceValid.value,
             )
@@ -138,12 +138,12 @@ private fun InputMenuSection(
         item {
             IconButton(onClick = {
                 isNameValid.value = inputMenuState.name.isNotBlank()
-                isPriceValid.value = price.isZeroOrPrimitiveInt()
+                isPriceValid.value = inputMenuState.price.isZeroOrPrimitiveInt()
 
                 if (isNameValid.value && isPriceValid.value) {
-                    menus.add(Menu(inputMenuState.name, price.toInt()))
+                    menus.add(Menu(inputMenuState.name, inputMenuState.price.toInt()))
                     inputMenuViewModel.onEvent(InputMenuUiEvent.NameChanged(""))
-                    setPrice("")
+                    inputMenuViewModel.onEvent(InputMenuUiEvent.PriceChanged(""))
                 }
             }) {
                 Icon(

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -28,10 +28,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -53,6 +51,7 @@ fun InputMenuScreen(
     navController: NavHostController = rememberNavController(),
     inputMenuViewModel: InputMenuViewModel = viewModel(),
 ) {
+    val menus by inputMenuViewModel.menusState.collectAsState()
     val inputMenuState by inputMenuViewModel.inputMenuState.collectAsState()
 
     Scaffold(
@@ -65,7 +64,6 @@ fun InputMenuScreen(
                     .padding(paddingValues),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            val menus = remember { mutableStateListOf<Menu>() }
             val isNameValid = remember { mutableStateOf(true) }
             val isPriceValid = remember { mutableStateOf(true) }
 
@@ -103,7 +101,7 @@ fun InputMenuScreen(
 
 @Composable
 private fun InputMenuSection(
-    menus: SnapshotStateList<Menu>,
+    menus: List<Menu>,
     isNameValid: MutableState<Boolean>,
     isPriceValid: MutableState<Boolean>,
     inputMenuState: InputMenuState,
@@ -119,7 +117,7 @@ private fun InputMenuSection(
         verticalArrangement = Arrangement.Top,
     ) {
         itemsIndexed(menus) { index, menu ->
-            CompletedMenuItem(menu) { menus.removeAt(index) }
+            CompletedMenuItem(menu) { inputMenuViewModel.onEvent(InputMenuUiEvent.RemoveMenu(index)) }
         }
 
         item {
@@ -141,7 +139,7 @@ private fun InputMenuSection(
                 isPriceValid.value = inputMenuState.price.isZeroOrPrimitiveInt()
 
                 if (isNameValid.value && isPriceValid.value) {
-                    menus.add(Menu(inputMenuState.name, inputMenuState.price.toInt()))
+//                    menus.add(Menu(inputMenuState.name, inputMenuState.price.toInt()))
                     inputMenuViewModel.onEvent(InputMenuUiEvent.NameChanged(""))
                     inputMenuViewModel.onEvent(InputMenuUiEvent.PriceChanged(""))
                 }
@@ -294,5 +292,5 @@ private fun TitleTextField(
 @Preview
 @Composable
 private fun InputMenuScreenPreview() {
-    InputMenuScreen(inputMenuViewModel = InputMenuViewModel())
+    InputMenuScreen(inputMenuViewModel = InputMenuViewModel(emptyList()))
 }

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -57,13 +58,16 @@ fun InputMenuScreen(navController: NavHostController = rememberNavController()) 
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             val menus = remember { mutableStateListOf<Menu>() }
+            val isNameValid = remember { mutableStateOf(true) }
+            val isPriceValid = remember { mutableStateOf(true) }
+
             Box(
                 modifier =
                     Modifier
                         .fillMaxWidth()
                         .weight(1f),
             ) {
-                InputMenuSection(menus)
+                InputMenuSection(menus, isNameValid, isPriceValid)
             }
             Divider()
             GsButton(
@@ -77,7 +81,12 @@ fun InputMenuScreen(navController: NavHostController = rememberNavController()) 
                     // TODO 서버로 메뉴 전송
                     Log.d("InputMenuScreen", "서버로 전송할 메뉴 목록\n ${menus.toList().joinToString("\n")}")
 
-                    navController.navigate(Screen.MAIN.route)
+                    if (menus.isEmpty()) {
+                        isNameValid.value = false
+                        isPriceValid.value = false
+                    } else {
+                        navController.navigate(Screen.MAIN.route)
+                    }
                 },
             )
         }
@@ -85,11 +94,13 @@ fun InputMenuScreen(navController: NavHostController = rememberNavController()) 
 }
 
 @Composable
-private fun InputMenuSection(menus: SnapshotStateList<Menu>) {
+private fun InputMenuSection(
+    menus: SnapshotStateList<Menu>,
+    isNameValid: MutableState<Boolean>,
+    isPriceValid: MutableState<Boolean>,
+) {
     val (name, setName) = remember { mutableStateOf("") }
     val (price, setPrice) = remember { mutableStateOf("") }
-    val isNameValid = remember { mutableStateOf(true) }
-    val isPriceValid = remember { mutableStateOf(true) }
 
     LazyColumn(
         modifier =

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -73,7 +72,7 @@ fun InputMenuScreen(
                         .fillMaxWidth()
                         .weight(1f),
             ) {
-                InputMenuSection(menus, isNameValid, isPriceValid, inputMenuState, inputMenuViewModel)
+                InputMenuSection(menus, inputMenuState, inputMenuViewModel)
             }
             Divider()
             GsButton(
@@ -102,8 +101,6 @@ fun InputMenuScreen(
 @Composable
 private fun InputMenuSection(
     menus: List<Menu>,
-    isNameValid: MutableState<Boolean>,
-    isPriceValid: MutableState<Boolean>,
     inputMenuState: InputMenuState,
     inputMenuViewModel: InputMenuViewModel,
 ) {
@@ -128,21 +125,14 @@ private fun InputMenuSection(
                 priceChanged = {
                     inputMenuViewModel.onEvent(InputMenuUiEvent.PriceChanged(it))
                 },
-                isNameValid = isNameValid.value,
-                isPriceValid = isPriceValid.value,
+                isNameValid = inputMenuState.isNameValid,
+                isPriceValid = inputMenuState.isPriceValid,
             )
         }
 
         item {
             IconButton(onClick = {
-                isNameValid.value = inputMenuState.name.isNotBlank()
-                isPriceValid.value = inputMenuState.price.isZeroOrPrimitiveInt()
-
-                if (isNameValid.value && isPriceValid.value) {
-//                    menus.add(Menu(inputMenuState.name, inputMenuState.price.toInt()))
-                    inputMenuViewModel.onEvent(InputMenuUiEvent.NameChanged(""))
-                    inputMenuViewModel.onEvent(InputMenuUiEvent.PriceChanged(""))
-                }
+                inputMenuViewModel.onEvent(InputMenuUiEvent.AddMenu)
             }) {
                 Icon(
                     imageVector = Icons.Default.AddCircleOutline,
@@ -151,11 +141,6 @@ private fun InputMenuSection(
             }
         }
     }
-}
-
-private fun String.isZeroOrPrimitiveInt(): Boolean {
-    val int = this.toIntOrNull() ?: return false
-    return int >= 0
 }
 
 @Composable
@@ -292,5 +277,5 @@ private fun TitleTextField(
 @Preview
 @Composable
 private fun InputMenuScreenPreview() {
-    InputMenuScreen(inputMenuViewModel = InputMenuViewModel(emptyList()))
+    InputMenuScreen(inputMenuViewModel = InputMenuViewModel(emptyList(), InputMenuState()))
 }

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuState.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuState.kt
@@ -1,0 +1,8 @@
+package com.erica.gamsung.menu.presentation
+
+data class InputMenuState(
+    val name: String = "",
+    val price: String = "",
+    val isNameValid: Boolean = true,
+    val isPriceValid: Boolean = true,
+)

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuUiEvent.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuUiEvent.kt
@@ -1,0 +1,19 @@
+package com.erica.gamsung.menu.presentation
+
+sealed interface InputMenuUiEvent {
+    data class NameChanged(
+        val name: String,
+    ) : InputMenuUiEvent
+
+    data class PriceChanged(
+        val price: String,
+    ) : InputMenuUiEvent
+
+    data object AddMenu : InputMenuUiEvent
+
+    data class RemoveMenu(
+        val index: Int,
+    ) : InputMenuUiEvent
+
+    data object SendMenus : InputMenuUiEvent
+}

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
@@ -1,0 +1,33 @@
+package com.erica.gamsung.menu.presentation
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class InputMenuViewModel : ViewModel() {
+    private var _inputMenuState = MutableStateFlow(InputMenuState())
+    val inputMenuState = _inputMenuState.asStateFlow()
+
+    fun onEvent(event: InputMenuUiEvent) {
+        when (event) {
+            is InputMenuUiEvent.NameChanged -> {
+                _inputMenuState.update {
+                    it.copy(
+                        name = event.name,
+                    )
+                }
+            }
+        }
+    }
+}
+
+sealed interface InputMenuUiEvent {
+    data class NameChanged(
+        val name: String,
+    ) : InputMenuUiEvent
+}
+
+data class InputMenuState(
+    val name: String = "",
+)

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
@@ -18,6 +18,14 @@ class InputMenuViewModel : ViewModel() {
                     )
                 }
             }
+
+            is InputMenuUiEvent.PriceChanged -> {
+                _inputMenuState.update {
+                    it.copy(
+                        price = event.price,
+                    )
+                }
+            }
         }
     }
 }
@@ -26,8 +34,13 @@ sealed interface InputMenuUiEvent {
     data class NameChanged(
         val name: String,
     ) : InputMenuUiEvent
+
+    data class PriceChanged(
+        val price: String,
+    ) : InputMenuUiEvent
 }
 
 data class InputMenuState(
     val name: String = "",
+    val price: String = "",
 )

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
@@ -19,73 +19,78 @@ class InputMenuViewModel(
     private var _shouldNavigateState = MutableStateFlow(false)
     val shouldNavigateState = _shouldNavigateState.asStateFlow()
 
-    @Suppress("LongMethod")
     fun onEvent(event: InputMenuUiEvent) {
         when (event) {
-            is InputMenuUiEvent.NameChanged -> {
-                _inputMenuState.update {
-                    it.copy(
-                        name = event.name,
-                    )
-                }
+            is InputMenuUiEvent.NameChanged -> handleNameChanged(event)
+            is InputMenuUiEvent.PriceChanged -> handlePriceChanged(event)
+            InputMenuUiEvent.AddMenu -> handleAddMenu()
+            is InputMenuUiEvent.RemoveMenu -> handleRemoveMenu(event)
+            InputMenuUiEvent.SendMenus -> handleSendMenus()
+        }
+    }
+
+    private fun handleNameChanged(event: InputMenuUiEvent.NameChanged) {
+        _inputMenuState.update {
+            it.copy(
+                name = event.name,
+            )
+        }
+    }
+
+    private fun handlePriceChanged(event: InputMenuUiEvent.PriceChanged) {
+        _inputMenuState.update {
+            it.copy(
+                price = event.price,
+            )
+        }
+    }
+
+    private fun handleAddMenu() {
+        val isNameValid = _inputMenuState.value.name.isNotBlank()
+        val isPriceValid = _inputMenuState.value.price.isZeroOrPrimitiveInt()
+
+        if (isNameValid && isPriceValid) {
+            _menusState.update {
+                it.plusElement(Menu(_inputMenuState.value.name, _inputMenuState.value.price.toInt()))
             }
 
-            is InputMenuUiEvent.PriceChanged -> {
-                _inputMenuState.update {
-                    it.copy(
-                        price = event.price,
-                    )
-                }
+            _inputMenuState.update {
+                it.copy(
+                    name = "",
+                    price = "",
+                    isNameValid = true,
+                    isPriceValid = true,
+                )
             }
-
-            InputMenuUiEvent.AddMenu -> {
-                val isNameValid = _inputMenuState.value.name.isNotBlank()
-                val isPriceValid = _inputMenuState.value.price.isZeroOrPrimitiveInt()
-
-                if (isNameValid && isPriceValid) {
-                    _menusState.update {
-                        it.plusElement(Menu(_inputMenuState.value.name, _inputMenuState.value.price.toInt()))
-                    }
-
-                    _inputMenuState.update {
-                        it.copy(
-                            name = "",
-                            price = "",
-                            isNameValid = true,
-                            isPriceValid = true,
-                        )
-                    }
-                } else {
-                    _inputMenuState.update {
-                        it.copy(
-                            isNameValid = isNameValid,
-                            isPriceValid = isPriceValid,
-                        )
-                    }
-                }
+        } else {
+            _inputMenuState.update {
+                it.copy(
+                    isNameValid = isNameValid,
+                    isPriceValid = isPriceValid,
+                )
             }
+        }
+    }
 
-            is InputMenuUiEvent.RemoveMenu -> {
-                _menusState.update {
-                    it.filterIndexed { index, _ -> index != event.index }
-                }
+    private fun handleRemoveMenu(event: InputMenuUiEvent.RemoveMenu) {
+        _menusState.update {
+            it.filterIndexed { index, _ -> index != event.index }
+        }
+    }
+
+    private fun handleSendMenus() {
+        val menus = _menusState.value
+
+        if (menus.isEmpty()) {
+            _inputMenuState.update {
+                it.copy(
+                    isNameValid = false,
+                    isPriceValid = false,
+                )
             }
-
-            InputMenuUiEvent.SendMenus -> {
-                val menus = _menusState.value
-
-                if (menus.isEmpty()) {
-                    _inputMenuState.update {
-                        it.copy(
-                            isNameValid = false,
-                            isPriceValid = false,
-                        )
-                    }
-                } else {
-                    // TODO 서버로 메뉴 전송
-                    _shouldNavigateState.value = true
-                }
-            }
+        } else {
+            // TODO 서버로 메뉴 전송
+            _shouldNavigateState.value = true
         }
     }
 

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
@@ -16,6 +16,10 @@ class InputMenuViewModel(
     private var _inputMenuState = MutableStateFlow(initialInputMenuState)
     val inputMenuState = _inputMenuState.asStateFlow()
 
+    private var _shouldNavigateState = MutableStateFlow(false)
+    val shouldNavigateState = _shouldNavigateState.asStateFlow()
+
+    @Suppress("LongMethod")
     fun onEvent(event: InputMenuUiEvent) {
         when (event) {
             is InputMenuUiEvent.NameChanged -> {
@@ -66,6 +70,22 @@ class InputMenuViewModel(
                     it.filterIndexed { index, _ -> index != event.index }
                 }
             }
+
+            InputMenuUiEvent.SendMenus -> {
+                val menus = _menusState.value
+
+                if (menus.isEmpty()) {
+                    _inputMenuState.update {
+                        it.copy(
+                            isNameValid = false,
+                            isPriceValid = false,
+                        )
+                    }
+                } else {
+                    // TODO 서버로 메뉴 전송
+                    _shouldNavigateState.value = true
+                }
+            }
         }
     }
 
@@ -89,6 +109,8 @@ sealed interface InputMenuUiEvent {
     data class RemoveMenu(
         val index: Int,
     ) : InputMenuUiEvent
+
+    data object SendMenus : InputMenuUiEvent
 }
 
 data class InputMenuState(

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
@@ -99,28 +99,3 @@ class InputMenuViewModel(
         return int >= 0
     }
 }
-
-sealed interface InputMenuUiEvent {
-    data class NameChanged(
-        val name: String,
-    ) : InputMenuUiEvent
-
-    data class PriceChanged(
-        val price: String,
-    ) : InputMenuUiEvent
-
-    data object AddMenu : InputMenuUiEvent
-
-    data class RemoveMenu(
-        val index: Int,
-    ) : InputMenuUiEvent
-
-    data object SendMenus : InputMenuUiEvent
-}
-
-data class InputMenuState(
-    val name: String = "",
-    val price: String = "",
-    val isNameValid: Boolean = true,
-    val isPriceValid: Boolean = true,
-)

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
@@ -1,11 +1,17 @@
 package com.erica.gamsung.menu.presentation
 
 import androidx.lifecycle.ViewModel
+import com.erica.gamsung.menu.domain.Menu
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
-class InputMenuViewModel : ViewModel() {
+class InputMenuViewModel(
+    initialMenus: List<Menu> = emptyList(),
+) : ViewModel() {
+    private var _menusState = MutableStateFlow(initialMenus)
+    val menusState = _menusState.asStateFlow()
+
     private var _inputMenuState = MutableStateFlow(InputMenuState())
     val inputMenuState = _inputMenuState.asStateFlow()
 
@@ -26,6 +32,12 @@ class InputMenuViewModel : ViewModel() {
                     )
                 }
             }
+
+            is InputMenuUiEvent.RemoveMenu -> {
+                _menusState.update {
+                    it.filterIndexed { index, _ -> index != event.index }
+                }
+            }
         }
     }
 }
@@ -37,6 +49,10 @@ sealed interface InputMenuUiEvent {
 
     data class PriceChanged(
         val price: String,
+    ) : InputMenuUiEvent
+
+    data class RemoveMenu(
+        val index: Int,
     ) : InputMenuUiEvent
 }
 

--- a/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
+++ b/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.erica.gamsung.menu.presentation
 
+import com.erica.gamsung.menu.domain.Menu
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 
 class InputMenuViewModelTest :
@@ -28,5 +31,30 @@ class InputMenuViewModelTest :
             // Then
             val price = viewModel.inputMenuState.value.price
             price shouldBe "3000"
+        }
+
+        test("RemoveMenu 이벤트로 메뉴를 제거할 수 있다.") {
+            // Given
+            val viewModel =
+                InputMenuViewModel(
+                    initialMenus =
+                        listOf(
+                            Menu("메뉴1", 1000),
+                            Menu("메뉴2", 2000),
+                            Menu("메뉴3", 3000),
+                        ),
+                )
+
+            // When
+            viewModel.onEvent(InputMenuUiEvent.RemoveMenu(1))
+
+            // Then
+            val menus = viewModel.menusState.value
+            menus shouldHaveSize 2
+            menus shouldContainInOrder
+                listOf(
+                    Menu("메뉴1", 1000),
+                    Menu("메뉴3", 3000),
+                )
         }
     })

--- a/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
+++ b/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
@@ -17,4 +17,16 @@ class InputMenuViewModelTest :
             val name = viewModel.inputMenuState.value.name
             name shouldBe "새 메뉴"
         }
+
+        test("PriceChanged 이벤트로 추가할 메뉴명을 수정할 수 있다.") {
+            // Given
+            val viewModel = InputMenuViewModel()
+
+            // When
+            viewModel.onEvent(InputMenuUiEvent.PriceChanged("3000"))
+
+            // Then
+            val price = viewModel.inputMenuState.value.price
+            price shouldBe "3000"
+        }
     })

--- a/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
+++ b/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
@@ -2,6 +2,7 @@ package com.erica.gamsung.menu.presentation
 
 import com.erica.gamsung.menu.domain.Menu
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -31,6 +32,69 @@ class InputMenuViewModelTest :
             // Then
             val price = viewModel.inputMenuState.value.price
             price shouldBe "3000"
+        }
+
+        test("AddMenu 이벤트로 메뉴를 추가할 수 있다.") {
+            // Given
+            val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "3000"))
+
+            // When
+            viewModel.onEvent(InputMenuUiEvent.AddMenu)
+
+            // Then
+            val menus = viewModel.menusState.value
+            menus shouldHaveSize 1
+            menus shouldContain Menu("새 메뉴", 3000)
+        }
+
+        test("메뉴명이 공백이거나 비어있으면 AddMenu 이벤트로 메뉴를 추가할 수 없다") {
+            // Given
+            val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState(" ", "3000"))
+
+            // When
+            viewModel.onEvent(InputMenuUiEvent.AddMenu)
+
+            // Then
+            val menus = viewModel.menusState.value
+            menus shouldHaveSize 0
+        }
+
+        test("가격이 숫자가 아니면 AddMenu 이벤트로 메뉴를 추가할 수 없다") {
+            // Given
+            val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "삼천원"))
+
+            // When
+            viewModel.onEvent(InputMenuUiEvent.AddMenu)
+
+            // Then
+            val menus = viewModel.menusState.value
+            menus shouldHaveSize 0
+        }
+
+        test("가격이 음수면 AddMenu 이벤트로 메뉴를 추가할 수 없다") {
+            // Given
+            val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "-3000"))
+
+            // When
+            viewModel.onEvent(InputMenuUiEvent.AddMenu)
+
+            // Then
+            val menus = viewModel.menusState.value
+            menus shouldHaveSize 0
+        }
+
+        test("AddMenu 이벤트로 메뉴 추가 후에 추가할 메뉴명과 추가할 가격은 빈 문자열로 초기화된다.") {
+            // Given
+            val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "3000"))
+
+            // When
+            viewModel.onEvent(InputMenuUiEvent.AddMenu)
+
+            // Then
+            val name = viewModel.inputMenuState.value.name
+            val price = viewModel.inputMenuState.value.price
+            name shouldBe ""
+            price shouldBe ""
         }
 
         test("RemoveMenu 이벤트로 메뉴를 제거할 수 있다.") {

--- a/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
+++ b/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
@@ -121,4 +121,42 @@ class InputMenuViewModelTest :
                     Menu("메뉴3", 3000),
                 )
         }
+
+        test("입력된 메뉴가 하나도 없을 시 SendEvent 이벤트 작동 후에 메인 페이지로 이동하면 안된다.") {
+            // Given
+            val viewModel = InputMenuViewModel(initialMenus = emptyList())
+
+            // When
+            viewModel.onEvent(InputMenuUiEvent.SendMenus)
+
+            // Then
+            val shouldNavigate = viewModel.shouldNavigateState.value
+            shouldNavigate shouldBe false
+        }
+
+        test("입력된 메뉴가 하나도 없을 시 SendEvent 이벤트 작동 후에 메뉴와 가격을 입력하라고 표시된다.") {
+            // Given
+            val viewModel = InputMenuViewModel(initialMenus = emptyList())
+
+            // When
+            viewModel.onEvent(InputMenuUiEvent.SendMenus)
+
+            // Then
+            val isNameValid = viewModel.inputMenuState.value.isNameValid
+            val isPriceValid = viewModel.inputMenuState.value.isPriceValid
+            isNameValid shouldBe false
+            isPriceValid shouldBe false
+        }
+
+        test("입력된 메뉴가 한 개 이상이면 SendEvent 이벤트 작동 후에 메인 페이지로 이동해도 된다.") {
+            // Given
+            val viewModel = InputMenuViewModel(initialMenus = listOf(Menu("입력된 메뉴", 1000)))
+
+            // When
+            viewModel.onEvent(InputMenuUiEvent.SendMenus)
+
+            // Then
+            val shouldNavigate = viewModel.shouldNavigateState.value
+            shouldNavigate shouldBe true
+        }
     })

--- a/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
+++ b/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
@@ -10,153 +10,163 @@ import io.kotest.matchers.shouldBe
 class InputMenuViewModelTest :
     FunSpec({
 
-        test("NameChanged 이벤트로 추가할 메뉴명을 수정할 수 있다.") {
-            // Given
-            val viewModel = InputMenuViewModel()
+        context("NameChanged 이벤트를 발생시켰을 때") {
+            test("추가할 메뉴명을 수정할 수 있다.") {
+                // Given
+                val viewModel = InputMenuViewModel()
 
-            // When
-            viewModel.onEvent(InputMenuUiEvent.NameChanged("새 메뉴"))
+                // When
+                viewModel.onEvent(InputMenuUiEvent.NameChanged("새 메뉴"))
 
-            // Then
-            val name = viewModel.inputMenuState.value.name
-            name shouldBe "새 메뉴"
+                // Then
+                val name = viewModel.inputMenuState.value.name
+                name shouldBe "새 메뉴"
+            }
         }
 
-        test("PriceChanged 이벤트로 추가할 메뉴명을 수정할 수 있다.") {
-            // Given
-            val viewModel = InputMenuViewModel()
+        context("PriceChanged 이벤트를 발생시켰을 때") {
+            test("추가할 메뉴명을 수정할 수 있다.") {
+                // Given
+                val viewModel = InputMenuViewModel()
 
-            // When
-            viewModel.onEvent(InputMenuUiEvent.PriceChanged("3000"))
+                // When
+                viewModel.onEvent(InputMenuUiEvent.PriceChanged("3000"))
 
-            // Then
-            val price = viewModel.inputMenuState.value.price
-            price shouldBe "3000"
+                // Then
+                val price = viewModel.inputMenuState.value.price
+                price shouldBe "3000"
+            }
         }
 
-        test("AddMenu 이벤트로 메뉴를 추가할 수 있다.") {
-            // Given
-            val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "3000"))
+        context("AddMenu 이벤트를 발생시켰을 때") {
+            test("메뉴를 추가할 수 있다.") {
+                // Given
+                val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "3000"))
 
-            // When
-            viewModel.onEvent(InputMenuUiEvent.AddMenu)
+                // When
+                viewModel.onEvent(InputMenuUiEvent.AddMenu)
 
-            // Then
-            val menus = viewModel.menusState.value
-            menus shouldHaveSize 1
-            menus shouldContain Menu("새 메뉴", 3000)
+                // Then
+                val menus = viewModel.menusState.value
+                menus shouldHaveSize 1
+                menus shouldContain Menu("새 메뉴", 3000)
+            }
+
+            test("메뉴명이 공백이거나 비어있으면 메뉴를 추가할 수 없다") {
+                // Given
+                val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState(" ", "3000"))
+
+                // When
+                viewModel.onEvent(InputMenuUiEvent.AddMenu)
+
+                // Then
+                val menus = viewModel.menusState.value
+                menus shouldHaveSize 0
+            }
+
+            test("가격이 숫자가 아니면 메뉴를 추가할 수 없다") {
+                // Given
+                val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "삼천원"))
+
+                // When
+                viewModel.onEvent(InputMenuUiEvent.AddMenu)
+
+                // Then
+                val menus = viewModel.menusState.value
+                menus shouldHaveSize 0
+            }
+
+            test("가격이 음수면 메뉴를 추가할 수 없다") {
+                // Given
+                val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "-3000"))
+
+                // When
+                viewModel.onEvent(InputMenuUiEvent.AddMenu)
+
+                // Then
+                val menus = viewModel.menusState.value
+                menus shouldHaveSize 0
+            }
+
+            test("메뉴 추가 후에 추가할 메뉴명과 추가할 가격은 빈 문자열로 초기화된다.") {
+                // Given
+                val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "3000"))
+
+                // When
+                viewModel.onEvent(InputMenuUiEvent.AddMenu)
+
+                // Then
+                val name = viewModel.inputMenuState.value.name
+                val price = viewModel.inputMenuState.value.price
+                name shouldBe ""
+                price shouldBe ""
+            }
         }
 
-        test("메뉴명이 공백이거나 비어있으면 AddMenu 이벤트로 메뉴를 추가할 수 없다") {
-            // Given
-            val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState(" ", "3000"))
+        context("RemoveMenu 이벤트를 발생시켰을 때") {
+            test("전달된 index의 메뉴를 제거할 수 있다.") {
+                // Given
+                val viewModel =
+                    InputMenuViewModel(
+                        initialMenus =
+                            listOf(
+                                Menu("메뉴1", 1000),
+                                Menu("메뉴2", 2000),
+                                Menu("메뉴3", 3000),
+                            ),
+                    )
 
-            // When
-            viewModel.onEvent(InputMenuUiEvent.AddMenu)
+                // When
+                viewModel.onEvent(InputMenuUiEvent.RemoveMenu(1))
 
-            // Then
-            val menus = viewModel.menusState.value
-            menus shouldHaveSize 0
+                // Then
+                val menus = viewModel.menusState.value
+                menus shouldHaveSize 2
+                menus shouldContainInOrder
+                    listOf(
+                        Menu("메뉴1", 1000),
+                        Menu("메뉴3", 3000),
+                    )
+            }
         }
 
-        test("가격이 숫자가 아니면 AddMenu 이벤트로 메뉴를 추가할 수 없다") {
-            // Given
-            val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "삼천원"))
+        context("SendEvent 이벤트를 발생시켰을 때") {
+            test("입력된 메뉴가 하나도 없을 시 메인 페이지로 이동하면 안된다.") {
+                // Given
+                val viewModel = InputMenuViewModel(initialMenus = emptyList())
 
-            // When
-            viewModel.onEvent(InputMenuUiEvent.AddMenu)
+                // When
+                viewModel.onEvent(InputMenuUiEvent.SendMenus)
 
-            // Then
-            val menus = viewModel.menusState.value
-            menus shouldHaveSize 0
-        }
+                // Then
+                val shouldNavigate = viewModel.shouldNavigateState.value
+                shouldNavigate shouldBe false
+            }
 
-        test("가격이 음수면 AddMenu 이벤트로 메뉴를 추가할 수 없다") {
-            // Given
-            val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "-3000"))
+            test("입력된 메뉴가 하나도 없을 시 메뉴와 가격을 입력하라고 표시된다.") {
+                // Given
+                val viewModel = InputMenuViewModel(initialMenus = emptyList())
 
-            // When
-            viewModel.onEvent(InputMenuUiEvent.AddMenu)
+                // When
+                viewModel.onEvent(InputMenuUiEvent.SendMenus)
 
-            // Then
-            val menus = viewModel.menusState.value
-            menus shouldHaveSize 0
-        }
+                // Then
+                val isNameValid = viewModel.inputMenuState.value.isNameValid
+                val isPriceValid = viewModel.inputMenuState.value.isPriceValid
+                isNameValid shouldBe false
+                isPriceValid shouldBe false
+            }
 
-        test("AddMenu 이벤트로 메뉴 추가 후에 추가할 메뉴명과 추가할 가격은 빈 문자열로 초기화된다.") {
-            // Given
-            val viewModel = InputMenuViewModel(initialInputMenuState = InputMenuState("새 메뉴", "3000"))
+            test("입력된 메뉴가 한 개 이상이면 메인 페이지로 이동해도 된다.") {
+                // Given
+                val viewModel = InputMenuViewModel(initialMenus = listOf(Menu("입력된 메뉴", 1000)))
 
-            // When
-            viewModel.onEvent(InputMenuUiEvent.AddMenu)
+                // When
+                viewModel.onEvent(InputMenuUiEvent.SendMenus)
 
-            // Then
-            val name = viewModel.inputMenuState.value.name
-            val price = viewModel.inputMenuState.value.price
-            name shouldBe ""
-            price shouldBe ""
-        }
-
-        test("RemoveMenu 이벤트로 메뉴를 제거할 수 있다.") {
-            // Given
-            val viewModel =
-                InputMenuViewModel(
-                    initialMenus =
-                        listOf(
-                            Menu("메뉴1", 1000),
-                            Menu("메뉴2", 2000),
-                            Menu("메뉴3", 3000),
-                        ),
-                )
-
-            // When
-            viewModel.onEvent(InputMenuUiEvent.RemoveMenu(1))
-
-            // Then
-            val menus = viewModel.menusState.value
-            menus shouldHaveSize 2
-            menus shouldContainInOrder
-                listOf(
-                    Menu("메뉴1", 1000),
-                    Menu("메뉴3", 3000),
-                )
-        }
-
-        test("입력된 메뉴가 하나도 없을 시 SendEvent 이벤트 작동 후에 메인 페이지로 이동하면 안된다.") {
-            // Given
-            val viewModel = InputMenuViewModel(initialMenus = emptyList())
-
-            // When
-            viewModel.onEvent(InputMenuUiEvent.SendMenus)
-
-            // Then
-            val shouldNavigate = viewModel.shouldNavigateState.value
-            shouldNavigate shouldBe false
-        }
-
-        test("입력된 메뉴가 하나도 없을 시 SendEvent 이벤트 작동 후에 메뉴와 가격을 입력하라고 표시된다.") {
-            // Given
-            val viewModel = InputMenuViewModel(initialMenus = emptyList())
-
-            // When
-            viewModel.onEvent(InputMenuUiEvent.SendMenus)
-
-            // Then
-            val isNameValid = viewModel.inputMenuState.value.isNameValid
-            val isPriceValid = viewModel.inputMenuState.value.isPriceValid
-            isNameValid shouldBe false
-            isPriceValid shouldBe false
-        }
-
-        test("입력된 메뉴가 한 개 이상이면 SendEvent 이벤트 작동 후에 메인 페이지로 이동해도 된다.") {
-            // Given
-            val viewModel = InputMenuViewModel(initialMenus = listOf(Menu("입력된 메뉴", 1000)))
-
-            // When
-            viewModel.onEvent(InputMenuUiEvent.SendMenus)
-
-            // Then
-            val shouldNavigate = viewModel.shouldNavigateState.value
-            shouldNavigate shouldBe true
+                // Then
+                val shouldNavigate = viewModel.shouldNavigateState.value
+                shouldNavigate shouldBe true
+            }
         }
     })

--- a/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
+++ b/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
@@ -1,0 +1,20 @@
+package com.erica.gamsung.menu.presentation
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class InputMenuViewModelTest :
+    FunSpec({
+
+        test("NameChanged 이벤트로 추가할 메뉴명을 수정할 수 있다.") {
+            // Given
+            val viewModel = InputMenuViewModel()
+
+            // When
+            viewModel.onEvent(InputMenuUiEvent.NameChanged("새 메뉴"))
+
+            // Then
+            val name = viewModel.inputMenuState.value.name
+            name shouldBe "새 메뉴"
+        }
+    })


### PR DESCRIPTION
## Issue
- close #29 

## Overview (Required)
- 메뉴 입력 페이지 구현을 MVVM 패턴으로 리팩터링한다
- InputMenuViewModel에 대해서 단위테스트를 작성한다

## Links
-

## Screenshot
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/d3bda1c4-956a-405e-8310-9fdf806c8ef1" width="450" />

---
MVVM 패턴으로 리팩터링하기 위해서 시도했는데 아무래도 맞게 한건진 잘 모르겠다...
일단 `InputMenuScreen` 안에 있던 비즈니스 로직들은 전부 `InputMenuViewModel`로 옮기는데에 성공했어.

확실히 비즈니스 로직을 `ViewModel`로 옮기는데 성공하니깐 단위 테스트를 작성하기가 되게 용이하더라.
그래서 내 생각엔 위의 사진처럼 테스트 코드를 통해 문서로서의 기능을 하도록 하는데에 성공한 것 같은데
형이 봤을 때도 그래보이는진 모르겠다

`InputMenuScreen`에서는 `ViewModel`의 `onEvent` 메서드를 통해서 이벤트를 발생시키고 `ViewModel`은 전달받은 이벤트에 따라서 이벤트를 처리하는 로직을 수행하는 방식으로 구현했어.
현재 구현에서는 메뉴명 변경, 가격 변경, 메뉴 추가, 메뉴 삭제, 메뉴 전송들이 이벤트야.

다만, 아직 `InputMenuScreen`에 대해서 테스트를 어떻게 작성해야 할지 감이 잘 안와서 작성못했어.
어쩌면 제대로 리팩터링하지 못해가지고 현재 테스트하기 어려운 구조여서 감이 안잡히는 것일수도 있어서
`InputMenuScreen`에 대한 Instrumented Test를 작성하는 이슈 등록해놓고 고민해볼게.

확인해보고 리뷰좀 ㅎ