### PR TITLE
Feature/#12 식당 정보 입력 페이지 디자인을 구현한다

### DIFF
--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.erica.gamsung.core.presentation
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -19,6 +21,7 @@ import com.erica.gamsung.store.presentation.InputStoreScreen
 import com.erica.gamsung.ui.theme.GamsungTheme
 
 class MainActivity : ComponentActivity() {
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -36,6 +39,7 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun MainNavHost(navController: NavHostController) {
     NavHost(navController = navController, startDestination = Screen.MAIN.route) {

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.erica.gamsung.menu.presentation.InputMenuScreen
 import com.erica.gamsung.menu.presentation.InputMenuViewModel
+import com.erica.gamsung.store.presentation.InputStoreScreen
 import com.erica.gamsung.ui.theme.GamsungTheme
 
 class MainActivity : ComponentActivity() {
@@ -42,6 +43,7 @@ fun MainNavHost(navController: NavHostController) {
         composable(Screen.SETTING.route) { SettingScreen() }
         composable(Screen.PUBLISH_POSTING.route) { PublishPostingScreen() }
         composable(Screen.CHECK_POSTING.route) { CheckPostingScreen() }
+        composable(Screen.INPUT_STORE.route) { InputStoreScreen(navController = navController) }
         composable(Screen.INPUT_MENU.route) {
             InputMenuScreen(navController = navController, inputMenuViewModel = InputMenuViewModel())
         }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
@@ -7,5 +7,6 @@ enum class Screen(
     SETTING("setting"),
     PUBLISH_POSTING("publishPosting"),
     CHECK_POSTING("checkPosting"),
+    INPUT_STORE("inputStore"),
     INPUT_MENU("inputMenu"),
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsButton.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsButton.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 
-private val Green = Color(0xFF1F7158)
 private val VividBlue = Color(0xFF1268FB)
 
 @Composable
@@ -28,7 +27,7 @@ fun GsButton(
     modifier: Modifier = Modifier,
     text: String,
     onClick: () -> Unit = {},
-    containerColor: Color = Green,
+    containerColor: Color = VividBlue,
 ) {
     Button(
         shape = RoundedCornerShape(10.dp),

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/TimeInputBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/TimeInputBox.kt
@@ -1,0 +1,33 @@
+package com.erica.gamsung.core.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TimeInput
+import androidx.compose.material3.TimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Suppress("MagicNumber")
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun TimeInputBox(timePickerState: TimePickerState) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(150.dp)
+                .clip(RoundedCornerShape(25))
+                .background(Color.White),
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        TimeInput(state = timePickerState)
+    }
+}

--- a/app/src/main/java/com/erica/gamsung/store/domain/StoreType.kt
+++ b/app/src/main/java/com/erica/gamsung/store/domain/StoreType.kt
@@ -1,0 +1,8 @@
+package com.erica.gamsung.store.domain
+
+enum class StoreType(
+    val description: String,
+) {
+    RESTAURANT("식당"),
+    CAFE("카페"),
+}

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -69,7 +69,7 @@ fun InputStoreScreen(navController: NavHostController = rememberNavController())
                 onOpenTimeUpdate = { /* TODO */ },
                 onCloseTimeUpdate = { /* TODO */ },
             )
-            StoreBusinessDaysSeciton(
+            StoreBusinessDaysSection(
                 onClick = { /* TODO */ },
                 week =
                     mapOf(
@@ -213,7 +213,7 @@ private fun HoursSection(
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-private fun StoreBusinessDaysSeciton(
+private fun StoreBusinessDaysSection(
     onClick: (DayOfWeek) -> Unit = {},
     week: Map<DayOfWeek, Boolean> =
         DayOfWeek.entries.associateWith { false },

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -1,5 +1,6 @@
 package com.erica.gamsung.store.presentation
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -7,13 +8,29 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimeInput
+import androidx.compose.material3.TimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.erica.gamsung.core.presentation.Screen
@@ -23,7 +40,9 @@ import com.erica.gamsung.core.presentation.component.GsTopAppBar
 import com.erica.gamsung.core.presentation.component.InputTextBox
 import com.erica.gamsung.core.presentation.component.TextTitle
 import com.erica.gamsung.store.domain.StoreType
+import com.erica.gamsung.store.presentation.utils.toDisplayString
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InputStoreScreen(navController: NavHostController = rememberNavController()) {
     Scaffold(
@@ -37,7 +56,12 @@ fun InputStoreScreen(navController: NavHostController = rememberNavController())
         ) {
             StoreNameSection(onValueChange = { /* TODO */ }, isValid = true)
             StoreTypeSection(onClick = { /* TODO */ }, selectedStoreType = StoreType.CAFE)
-            StoreBusinessHoursSection()
+            StoreBusinessHoursSection(
+                openTimePickerState = TimePickerState(0, 0, false),
+                closeTimePickerState = null,
+                onOpenTimeUpdate = { /* TODO */ },
+                onCloseTimeUpdate = { /* TODO */ },
+            )
             StoreBusinessDaysSeciton()
             StoreAddressSection()
             StorePhoneNumberSection()
@@ -85,8 +109,87 @@ private fun StoreTypeSection(
 }
 
 @Composable
-fun StoreBusinessHoursSection() {
-    Text(text = "StoreBusinessHoursSection") // TODO
+@OptIn(ExperimentalMaterial3Api::class)
+private fun StoreBusinessHoursSection(
+    openTimePickerState: TimePickerState?,
+    closeTimePickerState: TimePickerState?,
+    onOpenTimeUpdate: (TimePickerState) -> Unit,
+    onCloseTimeUpdate: (TimePickerState) -> Unit,
+) {
+    TextTitle(
+        title = "영업 시간",
+        isRequired = true,
+        description = null,
+        modifier = Modifier.padding(top = 10.dp),
+    )
+
+    Row {
+        HoursSection(
+            timePickerState = openTimePickerState,
+            onUpdate = onOpenTimeUpdate,
+            modifier = Modifier.weight(1f),
+            title = "시작시간",
+        )
+        HoursSection(
+            timePickerState = closeTimePickerState,
+            onUpdate = onCloseTimeUpdate,
+            modifier = Modifier.weight(1f),
+            title = "종료시간",
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HoursSection(
+    title: String,
+    timePickerState: TimePickerState?,
+    onUpdate: (TimePickerState) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showTimePicker by remember { mutableStateOf(false) }
+    val currentTimePickerState = remember { timePickerState ?: TimePickerState(0, 0, false) }
+
+    if (showTimePicker) {
+        Dialog(
+            onDismissRequest = {
+                onUpdate(currentTimePickerState)
+                showTimePicker = false
+            },
+        ) {
+            TimeInput(state = currentTimePickerState)
+        }
+    }
+
+    Column(
+        modifier = modifier.padding(end = 40.dp),
+    ) {
+        TextTitle(
+            title = title,
+            isRequired = false,
+            description = null,
+            modifier = Modifier.padding(top = 10.dp),
+        )
+        TextButton(
+            onClick = {
+                showTimePicker = true
+            },
+            colors = ButtonDefaults.textButtonColors(contentColor = Color.Gray),
+            shape = RoundedCornerShape(10.dp),
+            border = BorderStroke(1.dp, Color.Gray),
+        ) {
+            Icon(
+                imageVector = Icons.Default.AccessTime,
+                contentDescription = title,
+                modifier = Modifier.padding(end = 10.dp),
+            )
+            Text(
+                text = timePickerState?.toDisplayString() ?: "선택 안함",
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.weight(1f))
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -76,7 +77,7 @@ fun InputStoreScreen(navController: NavHostController = rememberNavController())
                     ),
             )
             StoreAddressSection(onValueChange = { /* TODO */ }, isValid = true)
-            StorePhoneNumberSection()
+            StorePhoneNumberSection(onValueChange = { /* TODO */ }, isValid = true)
             Spacer(modifier = Modifier.weight(1f))
             RegisterStoreButton(onClick = { navController.navigate(Screen.INPUT_MENU.route) })
         }
@@ -248,8 +249,17 @@ private fun StoreAddressSection(
 }
 
 @Composable
-fun StorePhoneNumberSection() {
-    Text(text = "StoreAddressSection") // TODO
+private fun StorePhoneNumberSection(
+    onValueChange: (String) -> Unit = {},
+    isValid: Boolean = true,
+) {
+    TitleTextField(
+        title = "전화 번호",
+        hintText = "ex. 010-1234-1234",
+        onValueChange = onValueChange,
+        isValid = isValid,
+        keyboardType = KeyboardType.Number,
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -17,6 +18,8 @@ import androidx.navigation.compose.rememberNavController
 import com.erica.gamsung.core.presentation.Screen
 import com.erica.gamsung.core.presentation.component.GsButton
 import com.erica.gamsung.core.presentation.component.GsTopAppBar
+import com.erica.gamsung.core.presentation.component.InputTextBox
+import com.erica.gamsung.core.presentation.component.TextTitle
 
 @Composable
 fun InputStoreScreen(navController: NavHostController = rememberNavController()) {
@@ -29,7 +32,7 @@ fun InputStoreScreen(navController: NavHostController = rememberNavController())
                     .fillMaxSize()
                     .padding(top = paddingValues.calculateTopPadding(), start = 8.dp, end = 8.dp),
         ) {
-            StoreNameSection()
+            StoreNameSection(onValueChange = { /* TODO */ }, isValid = true)
             StoreTypeSection()
             StoreBusinessHoursSection()
             StoreBusinessDaysSeciton()
@@ -42,8 +45,17 @@ fun InputStoreScreen(navController: NavHostController = rememberNavController())
 }
 
 @Composable
-fun StoreNameSection() {
-    Text(text = "StoreNameSection") // TODO
+fun StoreNameSection(
+    onValueChange: (String) -> Unit = {},
+    isValid: Boolean = true,
+) {
+    TitleTextField(
+        title = "음식점 이름",
+        hintText = "ex. 감성식당",
+        onValueChange = onValueChange,
+        isValid = isValid,
+        modifier = Modifier.fillMaxWidth(),
+    )
 }
 
 @Composable
@@ -82,6 +94,34 @@ private fun RegisterStoreButton(onClick: () -> Unit = {}) {
                 .padding(vertical = 12.dp),
         onClick = onClick,
     )
+}
+
+@Composable
+private fun TitleTextField(
+    modifier: Modifier = Modifier,
+    title: String,
+    hintText: String,
+    onValueChange: (String) -> Unit,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    isValid: Boolean = true,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        TextTitle(
+            title = title,
+            isRequired = true,
+            description = null,
+            modifier = Modifier.padding(vertical = 10.dp),
+        )
+        InputTextBox(
+            modifier = Modifier.fillMaxWidth(),
+            hintText = hintText,
+            onValueChange = onValueChange,
+            keyboardType = keyboardType,
+            isError = !isValid,
+        )
+    }
 }
 
 @Preview

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -1,6 +1,7 @@
 package com.erica.gamsung.store.presentation
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,9 +18,11 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.erica.gamsung.core.presentation.Screen
 import com.erica.gamsung.core.presentation.component.GsButton
+import com.erica.gamsung.core.presentation.component.GsChip
 import com.erica.gamsung.core.presentation.component.GsTopAppBar
 import com.erica.gamsung.core.presentation.component.InputTextBox
 import com.erica.gamsung.core.presentation.component.TextTitle
+import com.erica.gamsung.store.domain.StoreType
 
 @Composable
 fun InputStoreScreen(navController: NavHostController = rememberNavController()) {
@@ -33,7 +36,7 @@ fun InputStoreScreen(navController: NavHostController = rememberNavController())
                     .padding(top = paddingValues.calculateTopPadding(), start = 8.dp, end = 8.dp),
         ) {
             StoreNameSection(onValueChange = { /* TODO */ }, isValid = true)
-            StoreTypeSection()
+            StoreTypeSection(onClick = { /* TODO */ }, selectedStoreType = StoreType.CAFE)
             StoreBusinessHoursSection()
             StoreBusinessDaysSeciton()
             StoreAddressSection()
@@ -59,8 +62,26 @@ fun StoreNameSection(
 }
 
 @Composable
-fun StoreTypeSection() {
-    Text(text = "StoreTypeSection") // TODO
+private fun StoreTypeSection(
+    onClick: (StoreType) -> Unit = {},
+    selectedStoreType: StoreType? = null,
+) {
+    TextTitle(
+        title = "업종",
+        isRequired = true,
+        description = null,
+        modifier = Modifier.padding(top = 10.dp),
+    )
+    Row {
+        StoreType.entries.forEach { storeType ->
+            GsChip(
+                text = storeType.description,
+                selected = storeType == selectedStoreType,
+                modifier = Modifier.padding(end = 10.dp),
+                onClick = { onClick(storeType) },
+            )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -1,6 +1,7 @@
 package com.erica.gamsung.store.presentation
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -61,7 +62,19 @@ fun InputStoreScreen(navController: NavHostController = rememberNavController())
                 onOpenTimeUpdate = { /* TODO */ },
                 onCloseTimeUpdate = { /* TODO */ },
             )
-            StoreBusinessDaysSeciton()
+            StoreBusinessDaysSeciton(
+                onClick = { /* TODO */ },
+                week =
+                    mapOf(
+                        "일" to true,
+                        "월" to false,
+                        "화" to true,
+                        "수" to false,
+                        "목" to false,
+                        "금" to true,
+                        "토" to false,
+                    ),
+            )
             StoreAddressSection()
             StorePhoneNumberSection()
             Spacer(modifier = Modifier.weight(1f))
@@ -192,8 +205,33 @@ private fun HoursSection(
 }
 
 @Composable
-fun StoreBusinessDaysSeciton() {
-    Text(text = "StoreBusinessDaysSeciton") // TODO
+private fun StoreBusinessDaysSeciton(
+    onClick: (String) -> Unit = {},
+    week: Map<String, Boolean> =
+        mapOf(
+            "일" to false,
+            "월" to false,
+            "화" to false,
+            "수" to false,
+            "목" to false,
+            "금" to false,
+            "토" to false,
+        ),
+) {
+    TextTitle(
+        title = "영업일",
+        isRequired = true,
+        description = null,
+        modifier = Modifier.padding(top = 10.dp),
+    )
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        week.forEach {
+            GsChip(text = it.key, selected = it.value, onClick = { onClick(it.key) })
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -75,7 +75,7 @@ fun InputStoreScreen(navController: NavHostController = rememberNavController())
                         "토" to false,
                     ),
             )
-            StoreAddressSection()
+            StoreAddressSection(onValueChange = { /* TODO */ }, isValid = true)
             StorePhoneNumberSection()
             Spacer(modifier = Modifier.weight(1f))
             RegisterStoreButton(onClick = { navController.navigate(Screen.INPUT_MENU.route) })
@@ -235,8 +235,16 @@ private fun StoreBusinessDaysSeciton(
 }
 
 @Composable
-fun StoreAddressSection() {
-    Text(text = "StoreAddressSection") // TODO
+private fun StoreAddressSection(
+    onValueChange: (String) -> Unit = {},
+    isValid: Boolean = true,
+) {
+    TitleTextField(
+        title = "주소",
+        hintText = "ex. 안산시 상록구 한양대학로 99 1층",
+        onValueChange = onValueChange,
+        isValid = isValid,
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -1,0 +1,91 @@
+package com.erica.gamsung.store.presentation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.erica.gamsung.core.presentation.Screen
+import com.erica.gamsung.core.presentation.component.GsButton
+import com.erica.gamsung.core.presentation.component.GsTopAppBar
+
+@Composable
+fun InputStoreScreen(navController: NavHostController = rememberNavController()) {
+    Scaffold(
+        topBar = { GsTopAppBar(title = "식당 정보 입력 (1/2)") },
+    ) { paddingValues ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(top = paddingValues.calculateTopPadding(), start = 8.dp, end = 8.dp),
+        ) {
+            StoreNameSection()
+            StoreTypeSection()
+            StoreBusinessHoursSection()
+            StoreBusinessDaysSeciton()
+            StoreAddressSection()
+            StorePhoneNumberSection()
+            Spacer(modifier = Modifier.weight(1f))
+            RegisterStoreButton(onClick = { navController.navigate(Screen.INPUT_MENU.route) })
+        }
+    }
+}
+
+@Composable
+fun StoreNameSection() {
+    Text(text = "StoreNameSection") // TODO
+}
+
+@Composable
+fun StoreTypeSection() {
+    Text(text = "StoreTypeSection") // TODO
+}
+
+@Composable
+fun StoreBusinessHoursSection() {
+    Text(text = "StoreBusinessHoursSection") // TODO
+}
+
+@Composable
+fun StoreBusinessDaysSeciton() {
+    Text(text = "StoreBusinessDaysSeciton") // TODO
+}
+
+@Composable
+fun StoreAddressSection() {
+    Text(text = "StoreAddressSection") // TODO
+}
+
+@Composable
+fun StorePhoneNumberSection() {
+    Text(text = "StoreAddressSection") // TODO
+}
+
+@Composable
+private fun RegisterStoreButton(onClick: () -> Unit = {}) {
+    GsButton(
+        text = "가게 등록하기",
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(70.dp)
+                .padding(vertical = 12.dp),
+        onClick = onClick,
+    )
+}
+
+@Preview
+@Composable
+private fun InputStoreScreenPreveiw() {
+    InputStoreScreen()
+}

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -37,9 +36,9 @@ import com.erica.gamsung.core.presentation.Screen
 import com.erica.gamsung.core.presentation.component.GsButton
 import com.erica.gamsung.core.presentation.component.GsChip
 import com.erica.gamsung.core.presentation.component.GsTopAppBar
-import com.erica.gamsung.core.presentation.component.InputTextBox
 import com.erica.gamsung.core.presentation.component.TextTitle
 import com.erica.gamsung.store.domain.StoreType
+import com.erica.gamsung.store.presentation.components.TitleTextField
 import com.erica.gamsung.store.presentation.utils.toDisplayString
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -220,36 +219,8 @@ private fun RegisterStoreButton(onClick: () -> Unit = {}) {
     )
 }
 
-@Composable
-private fun TitleTextField(
-    modifier: Modifier = Modifier,
-    title: String,
-    hintText: String,
-    onValueChange: (String) -> Unit,
-    keyboardType: KeyboardType = KeyboardType.Text,
-    isValid: Boolean = true,
-) {
-    Column(
-        modifier = modifier,
-    ) {
-        TextTitle(
-            title = title,
-            isRequired = true,
-            description = null,
-            modifier = Modifier.padding(vertical = 10.dp),
-        )
-        InputTextBox(
-            modifier = Modifier.fillMaxWidth(),
-            hintText = hintText,
-            onValueChange = onValueChange,
-            keyboardType = keyboardType,
-            isError = !isValid,
-        )
-    }
-}
-
 @Preview
 @Composable
-private fun InputStoreScreenPreveiw() {
+private fun InputStoreScreenPreview() {
     InputStoreScreen()
 }

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TimeInput
 import androidx.compose.material3.TimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -41,6 +40,7 @@ import com.erica.gamsung.core.presentation.component.GsButton
 import com.erica.gamsung.core.presentation.component.GsChip
 import com.erica.gamsung.core.presentation.component.GsTopAppBar
 import com.erica.gamsung.core.presentation.component.TextTitle
+import com.erica.gamsung.core.presentation.component.TimeInputBox
 import com.erica.gamsung.store.domain.StoreType
 import com.erica.gamsung.store.presentation.components.TitleTextField
 import com.erica.gamsung.store.presentation.utils.toDisplayString
@@ -176,7 +176,7 @@ private fun HoursSection(
                 showTimePicker = false
             },
         ) {
-            TimeInput(state = currentTimePickerState)
+            TimeInputBox(currentTimePickerState)
         }
     }
 

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -1,5 +1,7 @@
 package com.erica.gamsung.store.presentation
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -42,7 +44,11 @@ import com.erica.gamsung.core.presentation.component.TextTitle
 import com.erica.gamsung.store.domain.StoreType
 import com.erica.gamsung.store.presentation.components.TitleTextField
 import com.erica.gamsung.store.presentation.utils.toDisplayString
+import java.time.DayOfWeek
+import java.time.format.TextStyle
+import java.util.Locale
 
+@RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InputStoreScreen(navController: NavHostController = rememberNavController()) {
@@ -67,13 +73,13 @@ fun InputStoreScreen(navController: NavHostController = rememberNavController())
                 onClick = { /* TODO */ },
                 week =
                     mapOf(
-                        "일" to true,
-                        "월" to false,
-                        "화" to true,
-                        "수" to false,
-                        "목" to false,
-                        "금" to true,
-                        "토" to false,
+                        DayOfWeek.SUNDAY to false,
+                        DayOfWeek.MONDAY to true,
+                        DayOfWeek.TUESDAY to false,
+                        DayOfWeek.WEDNESDAY to true,
+                        DayOfWeek.THURSDAY to false,
+                        DayOfWeek.FRIDAY to true,
+                        DayOfWeek.SATURDAY to false,
                     ),
             )
             StoreAddressSection(onValueChange = { /* TODO */ }, isValid = true)
@@ -205,19 +211,12 @@ private fun HoursSection(
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 private fun StoreBusinessDaysSeciton(
-    onClick: (String) -> Unit = {},
-    week: Map<String, Boolean> =
-        mapOf(
-            "일" to false,
-            "월" to false,
-            "화" to false,
-            "수" to false,
-            "목" to false,
-            "금" to false,
-            "토" to false,
-        ),
+    onClick: (DayOfWeek) -> Unit = {},
+    week: Map<DayOfWeek, Boolean> =
+        DayOfWeek.entries.associateWith { false },
 ) {
     TextTitle(
         title = "영업일",
@@ -229,8 +228,12 @@ private fun StoreBusinessDaysSeciton(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        week.forEach {
-            GsChip(text = it.key, selected = it.value, onClick = { onClick(it.key) })
+        week.forEach { (day, isSelected) ->
+            GsChip(
+                text = day.getDisplayName(TextStyle.SHORT, Locale.KOREA),
+                selected = isSelected,
+                onClick = { onClick(day) },
+            )
         }
     }
 }
@@ -275,6 +278,7 @@ private fun RegisterStoreButton(onClick: () -> Unit = {}) {
     )
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Preview
 @Composable
 private fun InputStoreScreenPreview() {

--- a/app/src/main/java/com/erica/gamsung/store/presentation/components/TitleTextField.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/components/TitleTextField.kt
@@ -1,0 +1,66 @@
+package com.erica.gamsung.store.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.erica.gamsung.core.presentation.component.InputTextBox
+import com.erica.gamsung.core.presentation.component.TextTitle
+
+@Composable
+fun TitleTextField(
+    modifier: Modifier = Modifier,
+    title: String,
+    hintText: String,
+    onValueChange: (String) -> Unit,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    isValid: Boolean = true,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        TextTitle(
+            title = title,
+            isRequired = true,
+            description = null,
+            modifier = Modifier.padding(vertical = 10.dp),
+        )
+        InputTextBox(
+            modifier = Modifier.fillMaxWidth(),
+            hintText = hintText,
+            onValueChange = onValueChange,
+            keyboardType = keyboardType,
+            isError = !isValid,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TitleTextFieldPreview() {
+    Column(
+        modifier = Modifier.background(Color.White),
+    ) {
+        TitleTextField(
+            title = "음식점 이름",
+            hintText = "ex. 감성식당",
+            onValueChange = {},
+            isValid = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        TitleTextField(
+            title = "음식점 이름",
+            hintText = "ex. 감성식당",
+            onValueChange = {},
+            isValid = false,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/app/src/main/java/com/erica/gamsung/store/presentation/utils/TimePickerExtensions.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/utils/TimePickerExtensions.kt
@@ -1,0 +1,14 @@
+package com.erica.gamsung.store.presentation.utils
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TimePickerState
+
+@Suppress("ImplicitDefaultLocale", "MagicNumber")
+@OptIn(ExperimentalMaterial3Api::class)
+fun TimePickerState.toDisplayString(): String {
+    val time = StringBuilder()
+    time.append(if (this.hour < 12) "AM" else "PM")
+    time.append(String.format(" %02d", if (this.hour % 12 == 0) 12 else this.hour % 12))
+    time.append(String.format(":%02d", this.minute))
+    return time.toString()
+}


### PR DESCRIPTION
## Issue
- close #12 

## Overview (Required)
- 식당 정보 입력 페이지 디자인을 구현한다

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/65f5fc8a-c205-4960-92a7-96ac262d2f6a" width="300" /> | <img src="https://github.com/ERICA-gamsung/android/assets/55042337/aa48d8bb-70d8-43f2-aa35-e3e082e5d962" width="300" />
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/34a98807-c318-4768-bc96-2db021fb5de3" width="300" /> | <img src="https://github.com/ERICA-gamsung/android/assets/55042337/d89926ba-e1a7-44aa-b0de-6bb63cf583c3" width="300" />

---

이번에 구현하면서 중점적으로 신경 쓴 건 구현할 때 `~~Section`라는 컴포저블로 쪼개서 구현을 진행한 점이야.
그리고 형 PR 참고해서 일주일 표현할 때 `DayOfWeek`로 리팩터링하니까 훨씬 깔끔해진듯. 
이 과정에서 `@RequiresApi(Build.VERSION_CODES.O)` 어노테이션을 추가해야 되더라고.
이게 `API 26 레벨 이상`에서만 실행될 수 있다고 명시하는 부분이던데 저번 PR에서 minSdk를 26으로 올린게 이거 때문 맞나??