### PR TITLE
Feature/#34 시간 선택 페이지(2) 디자인을 구현한다

### DIFF
--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -233,7 +233,7 @@ fun DropdownInputTextBox(
     var expanded by remember {
         mutableStateOf(false)
     }
-    var icon = if (expanded) Icons.Filled.ArrowDropUp else Icons.Filled.ArrowDropDown
+    val icon = if (expanded) Icons.Filled.ArrowDropUp else Icons.Filled.ArrowDropDown
 
     ExposedDropdownMenuBox(
         expanded = expanded,

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -140,6 +140,7 @@ private fun DropdownTextBox(
         readOnly = true,
         modifier =
             modifier
+                .fillMaxWidth()
                 .border(
                     1.dp,
                     Color.LightGray,
@@ -212,7 +213,7 @@ fun InputTextBox(
         shape = RoundedCornerShape(percent = 15),
         keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
         textStyle = MaterialTheme.typography.bodyLarge,
-        modifier = modifier,
+        modifier = modifier.fillMaxWidth(),
         isError = isError,
     )
 }
@@ -234,7 +235,11 @@ fun DropdownInputTextBox(
     }
     var icon = if (expanded) Icons.Filled.ArrowDropUp else Icons.Filled.ArrowDropDown
 
-    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }, modifier = modifier) {
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
+        modifier = modifier.fillMaxWidth(),
+    ) {
         OutlinedTextField(
             value = textState,
             onValueChange = {
@@ -260,7 +265,7 @@ fun DropdownInputTextBox(
             shape = RoundedCornerShape(percent = 15),
             textStyle = MaterialTheme.typography.bodyLarge,
             isError = isError,
-            modifier = modifier.menuAnchor(),
+            modifier = modifier.menuAnchor().fillMaxWidth(),
             trailingIcon = {
                 Icon(icon, "dropDownIcon")
             },

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTextBox.kt
@@ -13,8 +13,11 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -214,10 +217,76 @@ fun InputTextBox(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DropdownInputTextBox(
+    modifier: Modifier = Modifier,
+    hintText: String,
+    items: List<String>,
+    onValueChange: (String) -> Unit,
+    isError: Boolean = false,
+) {
+    var textState by remember {
+        mutableStateOf("")
+    }
+    var expanded by remember {
+        mutableStateOf(false)
+    }
+    var icon = if (expanded) Icons.Filled.ArrowDropUp else Icons.Filled.ArrowDropDown
+
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }, modifier = modifier) {
+        OutlinedTextField(
+            value = textState,
+            onValueChange = {
+                textState = it
+                onValueChange(it)
+            },
+            readOnly = true,
+            placeholder = {
+                Text(
+                    text = hintText,
+                    color = Color.Gray,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            },
+            singleLine = true,
+            colors =
+                TextFieldDefaults.colors(
+                    unfocusedContainerColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.LightGray,
+                    focusedContainerColor = Color.Transparent,
+                    errorContainerColor = Color.Transparent,
+                ),
+            shape = RoundedCornerShape(percent = 15),
+            textStyle = MaterialTheme.typography.bodyLarge,
+            isError = isError,
+            modifier = modifier.menuAnchor(),
+            trailingIcon = {
+                Icon(icon, "dropDownIcon")
+            },
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            items.forEach { label ->
+                DropdownMenuItem(
+                    onClick = {
+                        textState = label
+                        onValueChange(label)
+                        expanded = false
+                    },
+                    text = {
+                        Text(text = label)
+                    },
+                )
+            }
+        }
+    }
+}
+
 @Preview
 @Composable
 private fun GsTextPreview() {
     val options = listOf("option1", "option2", "option3")
+    var text by remember { mutableStateOf("") }
     Column(
         modifier = Modifier.background(Color.White),
     ) {
@@ -256,6 +325,13 @@ private fun GsTextPreview() {
             },
             modifier = Modifier.fillMaxWidth(1f),
             innerTextModifier = Modifier.padding(16.dp),
+        )
+        DropdownInputTextBox(
+            hintText = "test",
+            items = options,
+            onValueChange = { newText ->
+                text = newText
+            },
         )
     }
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/TimeInputBox.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/TimeInputBox.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
+// timePicker 배경
 @Suppress("MagicNumber")
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -24,7 +25,7 @@ fun TimeInputBox(timePickerState: TimePickerState) {
             Modifier
                 .fillMaxWidth()
                 .height(150.dp)
-                .clip(RoundedCornerShape(25))
+                .clip(RoundedCornerShape(10))
                 .background(Color.White),
         contentAlignment = Alignment.BottomCenter,
     ) {

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -216,7 +216,7 @@ private fun HoursSection(
 private fun StoreBusinessDaysSection(
     onClick: (DayOfWeek) -> Unit = {},
     week: Map<DayOfWeek, Boolean> =
-        DayOfWeek.entries.associateWith { false },
+        DayOfWeek.values().associateWith { false },
 ) {
     TextTitle(
         title = "영업일",

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
 
 package com.erica.gamsung.store.presentation
 
@@ -213,6 +212,7 @@ private fun HoursSection(
     }
 }
 
+@OptIn(ExperimentalStdlibApi::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 private fun StoreBusinessDaysSection(

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
 package com.erica.gamsung.store.presentation
 
 import android.os.Build
@@ -216,7 +218,7 @@ private fun HoursSection(
 private fun StoreBusinessDaysSection(
     onClick: (DayOfWeek) -> Unit = {},
     week: Map<DayOfWeek, Boolean> =
-        DayOfWeek.values().associateWith { false },
+        DayOfWeek.entries.associateWith { false },
 ) {
     TextTitle(
         title = "영업일",

--- a/app/src/main/java/com/erica/gamsung/uploadTime/presentation/CalendarScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/uploadTime/presentation/CalendarScreen.kt
@@ -56,6 +56,7 @@ fun MyCalendarScreen() {
                     }
                     selectedDatesMap[month] = updatedDates
                 },
+                onToggleValid = true,
             )
             Spacer(modifier = Modifier.height(32.dp))
             Text(

--- a/app/src/main/java/com/erica/gamsung/uploadTime/presentation/CalendarView.kt
+++ b/app/src/main/java/com/erica/gamsung/uploadTime/presentation/CalendarView.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -41,6 +42,13 @@ const val DATE_OF_FRAME = 42
 const val FILTER_NUM = 32
 const val CHUNK_NUM = 7
 
+enum class MoveDirection {
+    START,
+    LEFT,
+    RIGHT,
+}
+
+@Suppress("LongMethod")
 @Composable
 fun CalendarView(
     // focusedDate: LocalDate? = null,
@@ -50,30 +58,28 @@ fun CalendarView(
     var currentYearMonth by remember {
         mutableStateOf(YearMonth.now())
     }
+    val now = YearMonth.now()
     val selectedDatesMap =
         remember {
             mutableStateMapOf<YearMonth, List<LocalDate>>()
         }
-    var lastMove by remember {
-        mutableStateOf("START")
-    }
-    var check by remember {
-        mutableStateOf(false)
+
+    var moveDirection by remember {
+        mutableStateOf(MoveDirection.START)
     }
 
-    fun moveToPreviousMonth() {
-        if (lastMove == "RIGHT") {
-            currentYearMonth = currentYearMonth.minusMonths(1)
-            lastMove = "LEFT"
-            check = true
-        }
-    }
+    val canMoveLeft = currentYearMonth > now
+    val canMoveRight = currentYearMonth == now
 
-    fun moveToNextMonth() {
-        if (check || lastMove == "START") {
-            currentYearMonth = currentYearMonth.plusMonths(1)
-            lastMove = "RIGHT"
-            check = false
+    /*
+     *  Compose에서는 가능한 한 부작용(Side Effects)을 줄이고 순수 함수(pure functions)를 사용하는 것이 권장됩니다.
+     *  LaunchedEffect나 rememberCoroutineScope를 사용하여 이벤트를 처리하는 것이 좋습니다.
+     */
+    LaunchedEffect(moveDirection) {
+        when (moveDirection) {
+            MoveDirection.LEFT -> if (canMoveLeft) currentYearMonth = currentYearMonth.minusMonths(1)
+            MoveDirection.RIGHT -> if (canMoveRight) currentYearMonth = currentYearMonth.plusMonths(1)
+            else -> {} // START 상태일 때는 변경 없음
         }
     }
 
@@ -111,13 +117,13 @@ fun CalendarView(
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
                 contentDescription = "좌측 이동",
-                modifier = Modifier.clickable { moveToPreviousMonth() },
+                modifier = Modifier.clickable { moveDirection = MoveDirection.LEFT },
             )
             CalendarHeader(currentYearMonth)
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = "우측 이동",
-                modifier = Modifier.clickable { moveToNextMonth() },
+                modifier = Modifier.clickable { moveDirection = MoveDirection.RIGHT },
             )
         }
         Divider(

--- a/app/src/main/java/com/erica/gamsung/uploadTime/presentation/CalendarView.kt
+++ b/app/src/main/java/com/erica/gamsung/uploadTime/presentation/CalendarView.kt
@@ -45,6 +45,7 @@ const val CHUNK_NUM = 7
 fun CalendarView(
     // focusedDate: LocalDate? = null,
     onDateSelected: ((LocalDate, Boolean) -> Unit)? = null,
+    onToggleValid: Boolean,
 ) {
     var currentYearMonth by remember {
         mutableStateOf(YearMonth.now())
@@ -127,7 +128,7 @@ fun CalendarView(
         CalendarGrid(
             yearMonth = currentYearMonth,
             selectedDatesMap = selectedDatesMap,
-            onDateSelected = { date, isSelected -> toggleDateSelection(date, isSelected) },
+            onDateSelected = { date, isSelected -> if (onToggleValid) toggleDateSelection(date, isSelected) },
         )
     }
 }

--- a/app/src/main/java/com/erica/gamsung/uploadTime/presentation/ScheduleScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/uploadTime/presentation/ScheduleScreen.kt
@@ -1,5 +1,6 @@
 package com.erica.gamsung.uploadTime.presentation
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,7 +11,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
@@ -23,14 +34,18 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import com.erica.gamsung.core.presentation.component.DropdownInputTextBox
 import com.erica.gamsung.core.presentation.component.GsButton
 import com.erica.gamsung.core.presentation.component.GsOutlinedButton
 import com.erica.gamsung.core.presentation.component.InputTextBox
 import com.erica.gamsung.core.presentation.component.TextTitle
+import com.erica.gamsung.core.presentation.component.TimeInputBox
+import com.erica.gamsung.store.presentation.utils.toDisplayString
 import java.time.LocalDate
 import java.time.YearMonth
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Suppress("LongMethod")
 @Preview
 @Composable
@@ -42,7 +57,13 @@ fun MyScheduleScreen() {
     // 현재 달에 대한 초기 선택된 날짜 리스트 (예: 오늘)
     selectedDatesMap[currentMonth] = listOf(LocalDate.now())
 
-    var text by remember { mutableStateOf("") } // 사용자 입력을 저장할 상태 변수
+    // 사용자 입력을 저장할 상태 변수
+    var text by remember { mutableStateOf("") }
+
+    // TimePicker에 필요한 변수
+    var openTimePickerState = TimePickerState(0, 0, false)
+    var onOpenTimeUpdate: (TimePickerState) -> Unit = { /*TODO*/ }
+
     val options =
         listOf(
             "option1", "option2", "option3", "option1",
@@ -63,25 +84,17 @@ fun MyScheduleScreen() {
             Spacer(modifier = Modifier.height(16.dp))
             ScheduleView()
             // Spacer(modifier = Modifier.height(16.dp))
-            TitleTextField(
-                modifier =
-                    Modifier
-                        .padding(5.dp)
-                        .fillMaxWidth(),
-                title = "발행 시각",
-                description = " (기본값은 추천 시간입니다)",
-                hintText = "2024.02.19 09시 00분 ",
-                onValueChange = { newText ->
-                    text = newText
-                },
-                keyboardType = KeyboardType.Text,
-                isValid = true,
-            )
 
+            HoursSection(
+                title = "발행 시각",
+                timePickerState = openTimePickerState,
+                onUpdate = onOpenTimeUpdate,
+                modifier = Modifier,
+            )
             DropTitleTextField(
                 modifier =
                     Modifier
-                        .padding(5.dp)
+                        .padding(top = 5.dp, bottom = 5.dp)
                         .fillMaxWidth(),
                 title = "강조 메뉴",
                 hintText = "선택 없음",
@@ -96,7 +109,8 @@ fun MyScheduleScreen() {
             TitleTextField(
                 modifier =
                     Modifier
-                        .padding(5.dp),
+                        .padding(top = 5.dp, bottom = 5.dp)
+                        .fillMaxWidth(),
                 title = "고객에게 전하고 싶은 메세지",
                 description = (" (선택)"),
                 hintText = "ex. 서비스가 괜찮아요",
@@ -114,6 +128,59 @@ fun MyScheduleScreen() {
                 Spacer(modifier = Modifier.width(32.dp))
                 GsButton(text = "선택하기", containerColor = Color.Blue)
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HoursSection(
+    title: String,
+    timePickerState: TimePickerState?,
+    onUpdate: (TimePickerState) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showTimePicker by remember { mutableStateOf(false) }
+    val currentTimePickerState = remember { timePickerState ?: TimePickerState(0, 0, false) }
+
+    if (showTimePicker) {
+        Dialog(
+            onDismissRequest = {
+                onUpdate(currentTimePickerState)
+                showTimePicker = false
+            },
+        ) {
+            TimeInputBox(currentTimePickerState)
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        TextTitle(
+            title = title,
+            isRequired = true,
+            description = " (기본값은 추천 시간입니다)",
+            modifier = Modifier.padding(top = 10.dp),
+        )
+        TextButton(
+            onClick = {
+                showTimePicker = true
+            },
+            colors = ButtonDefaults.textButtonColors(contentColor = Color.Gray),
+            shape = RoundedCornerShape(10.dp),
+            border = BorderStroke(1.dp, Color.Gray),
+        ) {
+            Icon(
+                imageVector = Icons.Default.AccessTime,
+                contentDescription = title,
+                modifier = Modifier.padding(end = 10.dp),
+            )
+            Text(
+                text = timePickerState?.toDisplayString() ?: "선택 안함",
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.weight(1f))
         }
     }
 }
@@ -170,18 +237,14 @@ private fun DropTitleTextField(
             isRequired = isValid,
             description = description,
         )
-        Box(
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            DropdownInputTextBox(
-                modifier =
-                    Modifier
-                        .padding(top = 5.dp, end = 10.dp)
-                        .fillMaxWidth(),
-                hintText = hintText,
-                items = items,
-                onValueChange = onValueChange,
-            )
-        }
+        DropdownInputTextBox(
+            modifier =
+                Modifier
+                    .padding(top = 5.dp)
+                    .fillMaxWidth(),
+            hintText = hintText,
+            items = items,
+            onValueChange = onValueChange,
+        )
     }
 }

--- a/app/src/main/java/com/erica/gamsung/uploadTime/presentation/ScheduleScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/uploadTime/presentation/ScheduleScreen.kt
@@ -1,0 +1,187 @@
+package com.erica.gamsung.uploadTime.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.erica.gamsung.core.presentation.component.DropdownInputTextBox
+import com.erica.gamsung.core.presentation.component.GsButton
+import com.erica.gamsung.core.presentation.component.GsOutlinedButton
+import com.erica.gamsung.core.presentation.component.InputTextBox
+import com.erica.gamsung.core.presentation.component.TextTitle
+import java.time.LocalDate
+import java.time.YearMonth
+
+@Suppress("LongMethod")
+@Preview
+@Composable
+fun MyScheduleScreen() {
+    // 각 달별로 선택된 날짜들을 관리하기 위한 상태 맵
+    val selectedDatesMap = remember { mutableStateMapOf<YearMonth, List<LocalDate>>() }
+    // 현재 달을 기준으로 초기화
+    val currentMonth = YearMonth.now()
+    // 현재 달에 대한 초기 선택된 날짜 리스트 (예: 오늘)
+    selectedDatesMap[currentMonth] = listOf(LocalDate.now())
+
+    var text by remember { mutableStateOf("") } // 사용자 입력을 저장할 상태 변수
+    val options =
+        listOf(
+            "option1", "option2", "option3", "option1",
+            "option2", "option3", "option1", "option2",
+            "option3", "option1", "option2", "option3",
+        )
+
+    Scaffold {
+        Column(
+            modifier =
+                Modifier
+                    .padding(it)
+                    .padding(16.dp)
+                    .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+            ScheduleView()
+            // Spacer(modifier = Modifier.height(16.dp))
+            TitleTextField(
+                modifier =
+                    Modifier
+                        .padding(5.dp)
+                        .fillMaxWidth(),
+                title = "발행 시각",
+                description = " (기본값은 추천 시간입니다)",
+                hintText = "2024.02.19 09시 00분 ",
+                onValueChange = { newText ->
+                    text = newText
+                },
+                keyboardType = KeyboardType.Text,
+                isValid = true,
+            )
+
+            DropTitleTextField(
+                modifier =
+                    Modifier
+                        .padding(5.dp)
+                        .fillMaxWidth(),
+                title = "강조 메뉴",
+                hintText = "선택 없음",
+                description = (" (선택)"),
+                onValueChange = { newText ->
+                    text = newText
+                },
+                items = options,
+                isValid = false,
+            )
+            // Spacer(modifier = Modifier.height(8.dp))
+            TitleTextField(
+                modifier =
+                    Modifier
+                        .padding(5.dp),
+                title = "고객에게 전하고 싶은 메세지",
+                description = (" (선택)"),
+                hintText = "ex. 서비스가 괜찮아요",
+                onValueChange = { newText ->
+                    text = newText
+                },
+                keyboardType = KeyboardType.Text,
+                isValid = false,
+            )
+            // Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                GsOutlinedButton(text = "취소하기")
+                Spacer(modifier = Modifier.width(32.dp))
+                GsButton(text = "선택하기", containerColor = Color.Blue)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TitleTextField(
+    modifier: Modifier = Modifier,
+    title: String,
+    hintText: String,
+    description: String?,
+    onValueChange: (String) -> Unit,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    isValid: Boolean,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        TextTitle(
+            title = title,
+            isRequired = isValid,
+            description = description,
+        )
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            InputTextBox(
+                modifier =
+                    Modifier
+                        .padding(top = 5.dp, end = 10.dp)
+                        .fillMaxWidth(),
+                hintText = hintText,
+                onValueChange = onValueChange,
+                keyboardType = keyboardType,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DropTitleTextField(
+    modifier: Modifier = Modifier,
+    title: String,
+    hintText: String,
+    description: String?,
+    onValueChange: (String) -> Unit,
+    items: List<String>,
+    isValid: Boolean,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        TextTitle(
+            title = title,
+            isRequired = isValid,
+            description = description,
+        )
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            DropdownInputTextBox(
+                modifier =
+                    Modifier
+                        .padding(top = 5.dp, end = 10.dp)
+                        .fillMaxWidth(),
+                hintText = hintText,
+                items = items,
+                onValueChange = onValueChange,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/erica/gamsung/uploadTime/presentation/ScheduleView.kt
+++ b/app/src/main/java/com/erica/gamsung/uploadTime/presentation/ScheduleView.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -27,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import java.time.LocalDate
 import java.time.YearMonth
 
+@Suppress("LongMethod")
 @Composable
 fun ScheduleView(
     // focusedDate: LocalDate? = null,
@@ -35,30 +37,28 @@ fun ScheduleView(
     var currentYearMonth by remember {
         mutableStateOf(YearMonth.now())
     }
+    val now = YearMonth.now()
     val selectedDatesMap =
         remember {
             mutableStateMapOf<YearMonth, List<LocalDate>>()
         }
-    var lastMove by remember {
-        mutableStateOf("START")
-    }
-    var check by remember {
-        mutableStateOf(false)
+
+    var moveDirection by remember {
+        mutableStateOf(MoveDirection.START)
     }
 
-    fun moveToPreviousMonth() {
-        if (lastMove == "RIGHT") {
-            currentYearMonth = currentYearMonth.minusMonths(1)
-            lastMove = "LEFT"
-            check = true
-        }
-    }
+    val canMoveLeft = currentYearMonth > now
+    val canMoveRight = currentYearMonth == now
 
-    fun moveToNextMonth() {
-        if (check || lastMove == "START") {
-            currentYearMonth = currentYearMonth.plusMonths(1)
-            lastMove = "RIGHT"
-            check = false
+    /*
+     *  Compose에서는 가능한 한 부작용(Side Effects)을 줄이고 순수 함수(pure functions)를 사용하는 것이 권장됩니다.
+     *  LaunchedEffect나 rememberCoroutineScope를 사용하여 이벤트를 처리하는 것이 좋습니다.
+     */
+    LaunchedEffect(moveDirection) {
+        when (moveDirection) {
+            MoveDirection.LEFT -> if (canMoveLeft) currentYearMonth = currentYearMonth.minusMonths(1)
+            MoveDirection.RIGHT -> if (canMoveRight) currentYearMonth = currentYearMonth.plusMonths(1)
+            else -> {} // START 상태일 때는 변경 없음
         }
     }
 
@@ -82,13 +82,13 @@ fun ScheduleView(
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
                 contentDescription = "좌측 이동",
-                modifier = Modifier.clickable { moveToPreviousMonth() },
+                modifier = Modifier.clickable { moveDirection = MoveDirection.LEFT },
             )
             CalendarHeader(currentYearMonth)
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = "우측 이동",
-                modifier = Modifier.clickable { moveToNextMonth() },
+                modifier = Modifier.clickable { moveDirection = MoveDirection.RIGHT },
             )
         }
         Divider(

--- a/app/src/main/java/com/erica/gamsung/uploadTime/presentation/ScheduleView.kt
+++ b/app/src/main/java/com/erica/gamsung/uploadTime/presentation/ScheduleView.kt
@@ -1,0 +1,104 @@
+package com.erica.gamsung.uploadTime.presentation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import java.time.LocalDate
+import java.time.YearMonth
+
+@Composable
+fun ScheduleView(
+    // focusedDate: LocalDate? = null,
+    // onDateSelected: ((LocalDate, Boolean) -> Unit)? = null,
+) {
+    var currentYearMonth by remember {
+        mutableStateOf(YearMonth.now())
+    }
+    val selectedDatesMap =
+        remember {
+            mutableStateMapOf<YearMonth, List<LocalDate>>()
+        }
+    var lastMove by remember {
+        mutableStateOf("START")
+    }
+    var check by remember {
+        mutableStateOf(false)
+    }
+
+    fun moveToPreviousMonth() {
+        if (lastMove == "RIGHT") {
+            currentYearMonth = currentYearMonth.minusMonths(1)
+            lastMove = "LEFT"
+            check = true
+        }
+    }
+
+    fun moveToNextMonth() {
+        if (check || lastMove == "START") {
+            currentYearMonth = currentYearMonth.plusMonths(1)
+            lastMove = "RIGHT"
+            check = false
+        }
+    }
+
+    Column(
+        horizontalAlignment =
+            Alignment
+                .CenterHorizontally,
+        modifier =
+            Modifier
+                .background(color = Color.White)
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+                    shape = RoundedCornerShape(10.dp),
+                ).clip(RoundedCornerShape(10.dp)),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                contentDescription = "좌측 이동",
+                modifier = Modifier.clickable { moveToPreviousMonth() },
+            )
+            CalendarHeader(currentYearMonth)
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "우측 이동",
+                modifier = Modifier.clickable { moveToNextMonth() },
+            )
+        }
+        Divider(
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+            thickness = 1.dp,
+        )
+        DaysOfWeekRow()
+        CalendarGrid(
+            yearMonth = currentYearMonth,
+            selectedDatesMap = selectedDatesMap,
+        )
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.1" apply false
+    id("com.android.application") version "8.2.2" apply false
     id("org.jetbrains.kotlin.android") version "1.9.0" apply false
 
     // ktlint


### PR DESCRIPTION
## Issue
- close #34 

## Overview (Required)
- 페이지 구조
  - 달력 (포커싱 제외)
  - 시간 선택 ( 시간 선택 가능, 선택한 시간 반영 제외 )
  - 메뉴 선택 (dropdown 선택 반영 가능)
  - 하고 싶은 말 ( 타이핑 반영 가능)
  - 버튼 (클릭 가능 / 클릭 Action X)
## Links
-

## Screenshot
![image](https://github.com/ERICA-gamsung/android/assets/55565839/6b414208-cd94-40aa-a2b2-3d852e94a442)
