### PR TITLE
Feature/#30 서버로 메뉴 목록 전송하는 기능을 구현한다

### DIFF
--- a/.github/workflows/android-pull-request-ci.yml
+++ b/.github/workflows/android-pull-request-ci.yml
@@ -51,6 +51,11 @@ jobs:
       - name: set up Android SDK
         uses: android-actions/setup-android@v2
 
+      - name: Configure local.properties
+        run: |
+          echo SERVER_BASE_URL="${{ secrets.SERVER_BASE_URL }}" > local.properties
+        shell: bash
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,4 +82,8 @@ dependencies {
 
     // icons
     implementation("androidx.compose.material:material-icons-extended:1.6.1")
+
+    // retrofit
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -18,6 +20,7 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+        buildConfigField("String", "SERVER_BASE_URL", getApiKey("SERVER_BASE_URL"))
     }
 
     buildTypes {
@@ -38,6 +41,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"
@@ -87,3 +91,5 @@ dependencies {
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
 }
+
+fun getApiKey(propertyKey: String): String = gradleLocalProperties(rootDir).getProperty(propertyKey)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    kotlin("kapt")
 }
 
 android {
@@ -90,6 +91,11 @@ dependencies {
     // retrofit
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+
+    // room
+    implementation("androidx.room:room-runtime:2.6.1")
+    annotationProcessor("androidx.room:room-compiler:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
 }
 
 fun getApiKey(propertyKey: String): String = gradleLocalProperties(rootDir).getProperty(propertyKey)

--- a/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
+++ b/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
@@ -13,8 +13,8 @@ import androidx.navigation.testing.TestNavHostController
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.erica.gamsung.uploadTime.presentation.CalendarViewModel
 import com.erica.gamsung.core.di.GamsungDatabase
+import com.erica.gamsung.uploadTime.presentation.CalendarViewModel
 import org.junit.AfterClass
 import org.junit.Assert.*
 import org.junit.Before

--- a/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
+++ b/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
@@ -1,5 +1,6 @@
 package com.erica.gamsung.core.presentation
 
+import android.content.Context
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
@@ -9,10 +10,15 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.testing.TestNavHostController
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.erica.gamsung.uploadTime.presentation.CalendarViewModel
+import com.erica.gamsung.core.di.GamsungDatabase
+import org.junit.AfterClass
 import org.junit.Assert.*
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,14 +27,18 @@ import org.junit.runner.RunWith
 class MainScreenKtTest {
     @get:Rule
     val rule: ComposeContentTestRule = createComposeRule()
-    lateinit var navController: TestNavHostController
+    private lateinit var navController: TestNavHostController
 
     @Before
     fun setUp() {
         rule.setContent {
             navController = TestNavHostController(LocalContext.current)
             navController.navigatorProvider.addNavigator(ComposeNavigator())
-            MainNavHost(navController = navController, calendarViewModel = CalendarViewModel())
+            MainNavHost(
+                navController = navController,
+                calendarViewModel = CalendarViewModel(),
+                database = database,
+            )
         }
     }
 
@@ -87,5 +97,22 @@ class MainScreenKtTest {
 
         val route = navController.currentDestination?.route
         assertEquals(route, Screen.CHECK_POSTING.route)
+    }
+
+    companion object {
+        private lateinit var database: GamsungDatabase
+
+        @BeforeClass
+        @JvmStatic
+        fun createDb() {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+            database = Room.inMemoryDatabaseBuilder(context, GamsungDatabase::class.java).build()
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun closeDb() {
+            database.close()
+        }
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -11,6 +13,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Gamsung"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
             android:name=".core.presentation.MainActivity"

--- a/app/src/main/java/com/erica/gamsung/core/di/GamsungDatabase.kt
+++ b/app/src/main/java/com/erica/gamsung/core/di/GamsungDatabase.kt
@@ -1,0 +1,36 @@
+package com.erica.gamsung.core.di
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import com.erica.gamsung.menu.data.local.MenuDao
+import com.erica.gamsung.menu.data.local.MenuEntity
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.internal.synchronized
+
+@Database(entities = [MenuEntity::class], version = 1)
+abstract class GamsungDatabase : RoomDatabase() {
+    abstract fun menuDao(): MenuDao
+
+    companion object {
+        private var instance: GamsungDatabase? = null
+
+        @OptIn(InternalCoroutinesApi::class)
+        @Synchronized
+        fun getInstance(context: Context): GamsungDatabase? {
+            if (instance == null) {
+                synchronized(GamsungDatabase::class) {
+                    instance =
+                        Room
+                            .databaseBuilder(
+                                context.applicationContext,
+                                GamsungDatabase::class.java,
+                                "gamsung-database",
+                            ).build()
+                }
+            }
+            return instance
+        }
+    }
+}

--- a/app/src/main/java/com/erica/gamsung/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/erica/gamsung/core/di/NetworkModule.kt
@@ -4,7 +4,7 @@ import com.erica.gamsung.BuildConfig
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-object SingletonModule {
+object NetworkModule {
     private const val BASE_URL = BuildConfig.SERVER_BASE_URL
 
     val retrofit: Retrofit =

--- a/app/src/main/java/com/erica/gamsung/core/di/SingletonModule.kt
+++ b/app/src/main/java/com/erica/gamsung/core/di/SingletonModule.kt
@@ -1,0 +1,16 @@
+package com.erica.gamsung.core.di
+
+import com.erica.gamsung.BuildConfig
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object SingletonModule {
+    private const val BASE_URL = BuildConfig.SERVER_BASE_URL
+
+    val retrofit: Retrofit =
+        Retrofit
+            .Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+}

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -43,7 +43,7 @@ class MainActivity : ComponentActivity() {
                     MainNavHost(
                         navController = navController,
                         calendarViewModel = calendarViewModel,
-                        database = database
+                        database = database,
                     )
                 }
             }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -14,10 +14,10 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.erica.gamsung.core.presentation.theme.GamsungTheme
 import com.erica.gamsung.menu.presentation.InputMenuScreen
 import com.erica.gamsung.menu.presentation.InputMenuViewModel
 import com.erica.gamsung.store.presentation.InputStoreScreen
-import com.erica.gamsung.ui.theme.GamsungTheme
 import com.erica.gamsung.uploadTime.presentation.CalendarViewModel
 import com.erica.gamsung.uploadTime.presentation.MyCalendarScreen
 import com.erica.gamsung.uploadTime.presentation.MyScheduleScreen

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -14,7 +14,10 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.erica.gamsung.core.di.GamsungDatabase
 import com.erica.gamsung.core.presentation.theme.GamsungTheme
+import com.erica.gamsung.menu.data.remote.MenuApi
+import com.erica.gamsung.menu.data.repository.MenuRepositoryImpl
 import com.erica.gamsung.menu.presentation.InputMenuScreen
 import com.erica.gamsung.menu.presentation.InputMenuViewModel
 import com.erica.gamsung.store.presentation.InputStoreScreen
@@ -27,6 +30,7 @@ import com.erica.gamsung.uploadTime.presentation.MyScheduleScreen
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val database = GamsungDatabase.getInstance(this)!!
         setContent {
             GamsungTheme {
                 Surface(
@@ -36,7 +40,11 @@ class MainActivity : ComponentActivity() {
                     val navController = rememberNavController()
                     // ViewModel 여기서 생성
                     val calendarViewModel: CalendarViewModel = viewModel()
-                    MainNavHost(navController, calendarViewModel)
+                    MainNavHost(
+                        navController = navController,
+                        calendarViewModel = calendarViewModel,
+                        database = database
+                    )
                 }
             }
         }
@@ -47,6 +55,7 @@ class MainActivity : ComponentActivity() {
 fun MainNavHost(
     navController: NavHostController,
     calendarViewModel: CalendarViewModel,
+    database: GamsungDatabase,
 ) {
     NavHost(navController = navController, startDestination = Screen.MAIN.route) {
         composable(Screen.MAIN.route) { MainScreen(navController = navController) }
@@ -55,7 +64,17 @@ fun MainNavHost(
         composable(Screen.CHECK_POSTING.route) { CheckPostingScreen() }
         composable(Screen.INPUT_STORE.route) { InputStoreScreen(navController = navController) }
         composable(Screen.INPUT_MENU.route) {
-            InputMenuScreen(navController = navController, inputMenuViewModel = InputMenuViewModel())
+            InputMenuScreen(
+                navController = navController,
+                inputMenuViewModel =
+                    InputMenuViewModel(
+                        menuRepository =
+                            MenuRepositoryImpl(
+                                menuDao = database.menuDao(),
+                                menuApi = MenuApi.service,
+                            ),
+                    ),
+            )
         }
         composable(Screen.DATE_SELECT.route) {
             MyCalendarScreen(navController = navController, viewModel = calendarViewModel)

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -1,10 +1,8 @@
 package com.erica.gamsung.core.presentation
 
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -27,7 +25,6 @@ import com.erica.gamsung.uploadTime.presentation.MyScheduleScreen
 // 동일한 viewmodel을 2개의 page가 공유하기 위해서는 hilt를 이용한 DI가 필요하다고 한다.
 // 일단은 상위 컴포넌트에서 생성해서 사용.
 class MainActivity : ComponentActivity() {
-    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -46,7 +43,6 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun MainNavHost(
     navController: NavHostController,

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsButton.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsButton.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -84,7 +84,7 @@ fun GsTextButtonWithIcon(
             )
             Spacer(modifier = Modifier.weight(1f))
             Icon(
-                imageVector = Icons.Default.KeyboardArrowRight,
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = "KeyboardArrowRight",
             )
         },

--- a/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTopAppBar.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/component/GsTopAppBar.kt
@@ -2,7 +2,7 @@ package com.erica.gamsung.core.presentation.component
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -32,7 +32,7 @@ fun GsTopAppBar(
                     onClick = onNavigationClick,
                     content = {
                         Icon(
-                            imageVector = Icons.Default.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "PreviousButton",
                         )
                     },

--- a/app/src/main/java/com/erica/gamsung/core/presentation/theme/Color.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.erica.gamsung.ui.theme
+package com.erica.gamsung.core.presentation.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/erica/gamsung/core/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.erica.gamsung.ui.theme
+package com.erica.gamsung.core.presentation.theme
 
 import android.app.Activity
 import android.os.Build

--- a/app/src/main/java/com/erica/gamsung/core/presentation/theme/Type.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.erica.gamsung.ui.theme
+package com.erica.gamsung.core.presentation.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/java/com/erica/gamsung/menu/data/MenuMappers.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/data/MenuMappers.kt
@@ -1,0 +1,11 @@
+package com.erica.gamsung.menu.data
+
+import com.erica.gamsung.menu.data.local.MenuEntity
+import com.erica.gamsung.menu.data.remote.UpdateMenusResponse
+
+fun UpdateMenusResponse.toMenuEntity(): MenuEntity =
+    MenuEntity(
+        id = id,
+        name = name,
+        price = price,
+    )

--- a/app/src/main/java/com/erica/gamsung/menu/data/local/MenuDao.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/data/local/MenuDao.kt
@@ -1,0 +1,22 @@
+package com.erica.gamsung.menu.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+
+@Dao
+interface MenuDao {
+    @Query("DELETE FROM menus")
+    fun deleteAll()
+
+    @Insert
+    fun insertAll(vararg menus: MenuEntity)
+
+    @Suppress("SpreadOperator")
+    @Transaction
+    fun updateAll(menus: List<MenuEntity>) {
+        deleteAll()
+        insertAll(*menus.toTypedArray())
+    }
+}

--- a/app/src/main/java/com/erica/gamsung/menu/data/local/MenuEntity.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/data/local/MenuEntity.kt
@@ -1,0 +1,12 @@
+package com.erica.gamsung.menu.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "menus")
+data class MenuEntity(
+    @PrimaryKey
+    val id: Long,
+    val name: String,
+    val price: Int,
+)

--- a/app/src/main/java/com/erica/gamsung/menu/data/remote/MenuApi.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/data/remote/MenuApi.kt
@@ -1,18 +1,18 @@
 package com.erica.gamsung.menu.data.remote
 
-import com.erica.gamsung.core.di.SingletonModule
+import com.erica.gamsung.core.di.NetworkModule
 import retrofit2.http.Body
 import retrofit2.http.PUT
-import retrofit2.http.Query
+import retrofit2.http.Path
 
 interface MenuApi {
     @PUT("menu/put/{userId}")
     suspend fun updateMenus(
-        @Query("userId") userId: Long = 1L,
+        @Path("userId") userId: Long = 1L,
         @Body request: List<UpdateMenusRequest>,
     ): List<UpdateMenusResponse>
 
     companion object {
-        val service: MenuApi = SingletonModule.retrofit.create(MenuApi::class.java)
+        val service: MenuApi = NetworkModule.retrofit.create(MenuApi::class.java)
     }
 }

--- a/app/src/main/java/com/erica/gamsung/menu/data/remote/MenuApi.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/data/remote/MenuApi.kt
@@ -1,0 +1,18 @@
+package com.erica.gamsung.menu.data.remote
+
+import com.erica.gamsung.core.di.SingletonModule
+import retrofit2.http.Body
+import retrofit2.http.PUT
+import retrofit2.http.Query
+
+interface MenuApi {
+    @PUT("menu/put/{userId}")
+    suspend fun updateMenus(
+        @Query("userId") userId: Long = 1L,
+        @Body request: List<UpdateMenusRequest>,
+    ): List<UpdateMenusResponse>
+
+    companion object {
+        val service: MenuApi = SingletonModule.retrofit.create(MenuApi::class.java)
+    }
+}

--- a/app/src/main/java/com/erica/gamsung/menu/data/remote/MenuDtos.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/data/remote/MenuDtos.kt
@@ -1,0 +1,12 @@
+package com.erica.gamsung.menu.data.remote
+
+data class UpdateMenusRequest(
+    val name: String,
+    val price: Int,
+)
+
+data class UpdateMenusResponse(
+    val id: Long,
+    val name: String,
+    val price: Int,
+)

--- a/app/src/main/java/com/erica/gamsung/menu/data/repository/FakeMenuRepositoryImpl.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/data/repository/FakeMenuRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package com.erica.gamsung.menu.data.repository
+
+import com.erica.gamsung.menu.domain.Menu
+import com.erica.gamsung.menu.domain.MenuRepository
+
+class FakeMenuRepositoryImpl : MenuRepository {
+    private var db = listOf<Menu>()
+
+    override suspend fun updateMenus(menus: List<Menu>) {
+        db = menus
+    }
+}

--- a/app/src/main/java/com/erica/gamsung/menu/data/repository/MenuRepositoryImpl.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/data/repository/MenuRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package com.erica.gamsung.menu.data.repository
+
+import com.erica.gamsung.menu.data.local.MenuDao
+import com.erica.gamsung.menu.data.remote.MenuApi
+import com.erica.gamsung.menu.data.remote.UpdateMenusRequest
+import com.erica.gamsung.menu.data.toMenuEntity
+import com.erica.gamsung.menu.domain.Menu
+import com.erica.gamsung.menu.domain.MenuRepository
+
+class MenuRepositoryImpl(
+    private val menuDao: MenuDao,
+    private val menuApi: MenuApi,
+) : MenuRepository {
+    override suspend fun updateMenus(menus: List<Menu>) {
+        // 1. 서버에 메뉴 수정 요청
+        val updatedMenus =
+            menuApi.updateMenus(
+                request =
+                    menus.map { menu ->
+                        UpdateMenusRequest(name = menu.name, price = menu.price)
+                    },
+            )
+
+        // 2. 로컬 DB에 메뉴 저장
+        menuDao.updateAll(
+            updatedMenus.map { updateMenusResponse ->
+                updateMenusResponse.toMenuEntity()
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/erica/gamsung/menu/domain/MenuRepository.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/domain/MenuRepository.kt
@@ -1,0 +1,5 @@
+package com.erica.gamsung.menu.domain
+
+interface MenuRepository {
+    suspend fun updateMenus(menus: List<Menu>)
+}

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
@@ -2,13 +2,18 @@ package com.erica.gamsung.menu.presentation
 
 import androidx.lifecycle.ViewModel
 import com.erica.gamsung.menu.domain.Menu
+import com.erica.gamsung.menu.domain.MenuRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 class InputMenuViewModel(
     initialMenus: List<Menu> = emptyList(),
     initialInputMenuState: InputMenuState = InputMenuState(),
+    private val menuRepository: MenuRepository,
 ) : ViewModel() {
     private var _menusState = MutableStateFlow(initialMenus)
     val menusState = _menusState.asStateFlow()
@@ -89,8 +94,13 @@ class InputMenuViewModel(
                 )
             }
         } else {
-            // TODO 서버로 메뉴 전송
-            _shouldNavigateState.value = true
+            CoroutineScope(Dispatchers.IO).launch {
+                runCatching {
+                    menuRepository.updateMenus(menus)
+                }.onSuccess {
+                    _shouldNavigateState.value = true
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuViewModel.kt
@@ -1,6 +1,7 @@
 package com.erica.gamsung.menu.presentation
 
 import androidx.lifecycle.ViewModel
+import com.erica.gamsung.menu.data.repository.FakeMenuRepositoryImpl
 import com.erica.gamsung.menu.domain.Menu
 import com.erica.gamsung.menu.domain.MenuRepository
 import kotlinx.coroutines.CoroutineScope
@@ -13,7 +14,7 @@ import kotlinx.coroutines.launch
 class InputMenuViewModel(
     initialMenus: List<Menu> = emptyList(),
     initialInputMenuState: InputMenuState = InputMenuState(),
-    private val menuRepository: MenuRepository,
+    private val menuRepository: MenuRepository = FakeMenuRepositoryImpl(),
 ) : ViewModel() {
     private var _menusState = MutableStateFlow(initialMenus)
     val menusState = _menusState.asStateFlow()

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -1,8 +1,5 @@
-
 package com.erica.gamsung.store.presentation
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -49,7 +46,6 @@ import java.time.DayOfWeek
 import java.time.format.TextStyle
 import java.util.Locale
 
-@RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InputStoreScreen(navController: NavHostController = rememberNavController()) {
@@ -212,8 +208,6 @@ private fun HoursSection(
     }
 }
 
-@OptIn(ExperimentalStdlibApi::class)
-@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 private fun StoreBusinessDaysSection(
     onClick: (DayOfWeek) -> Unit = {},
@@ -280,7 +274,6 @@ private fun RegisterStoreButton(onClick: () -> Unit = {}) {
     )
 }
 
-@RequiresApi(Build.VERSION_CODES.O)
 @Preview
 @Composable
 private fun InputStoreScreenPreview() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
 
     // detekt
     id("io.gitlab.arturbosch.detekt") version("1.23.4")
+
+    // kapt
+    kotlin("kapt") version "1.9.0" apply false
 }
 
 allprojects {


### PR DESCRIPTION
## Issue
- close #30 

## Overview (Required)
- 서버로 메뉴 목록 전송하는 기능을 구현한다
- 서버로부터 받은 id와 함께 로컬 DB에 메뉴를 저장한다.

## Links
-

## Screenshot
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/958f2ed4-c07b-4ea9-ba67-6c12f11a55f8" width="300" />
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/495a040c-e3ef-40e1-9722-24c64f6ec2a7" width="600" />
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/f471ebe9-0c68-4bfa-abbc-db94f2592fc3" width="600" />

---

이것저것 라이브러리 많이 처음 추가하고 설정하다 보니까 PR 양이 너무 커진 것 같네...
그래서 파일 코멘트로 최대한 많이 설명 남겨놨어.

현재 "메뉴 등록하기 버튼을 눌렀을 때 입력된 메뉴가 한 개 이상이면 메인 페이지로 이동해도 된다." 테스트가 실패해.
아마 비동기랑 연관되서 실패하는 것 같아서 이거 이슈 추가해놓을게. (#41 추가완료)

그리고 Hilt 도입시에 싱글톤으로 `Retrofit`이랑 `RoomDatabase` 를 편하게 관리할 수 있고
`MainActivity`의 코드들이 뭔가 이것저것 `ViewModel`이랑 `Database`같은 것을 주입해야 해서 파일이 커지고 있는데
이에 대해서도 해결할 수 있을 것 같은데 도입하는 거 어떻게 생각해??
만약 도입한다면 이것도 `Hilt를 도입한다` 같이 이슈 만들어도 괜찮을 것 같아.
