### PR TITLE
Feature/#21 마이 페이지 디자인을 구현한다

### DIFF
--- a/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
+++ b/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
@@ -57,7 +57,7 @@ class MainScreenKtTest {
             .performClick()
 
         val route = navController.currentDestination?.route
-        assertEquals(route, Screen.SETTING.route)
+        assertEquals(route, Screen.Setting.route)
     }
 
     /** 메인 페이지에 글 발행 버튼이 화면에 보인다 */
@@ -76,7 +76,7 @@ class MainScreenKtTest {
             .performClick()
 
         val route = navController.currentDestination?.route
-        assertEquals(route, Screen.PUBLISH_POSTING.route)
+        assertEquals(route, Screen.PublishPosting.route)
     }
 
     /** 메인 페이지에 발행 현황 확인 버튼이 화면에 보인다 */
@@ -95,7 +95,7 @@ class MainScreenKtTest {
             .performClick()
 
         val route = navController.currentDestination?.route
-        assertEquals(route, Screen.CHECK_POSTING.route)
+        assertEquals(route, Screen.CheckPosting.route)
     }
 
     companion object {

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.navigation.compose.rememberNavController
 import com.erica.gamsung.core.presentation.theme.GamsungTheme
 import com.erica.gamsung.login.presentation.LoginScreen
 import com.erica.gamsung.menu.presentation.InputMenuScreen
+import com.erica.gamsung.setting.presentation.SettingScreen
 import com.erica.gamsung.store.presentation.InputStoreScreen
 import com.erica.gamsung.uploadTime.presentation.CalendarViewModel
 import com.erica.gamsung.uploadTime.presentation.MyCalendarScreen
@@ -72,11 +73,6 @@ fun MainNavHost(
         }
         composable(Screen.LOGIN.route) { LoginScreen(navController = navController) }
     }
-}
-
-@Composable
-fun SettingScreen() {
-    Text(text = "SettingScreen") // TODO 구현 시작 시 제거 및 코드 이동
 }
 
 @Composable

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -60,8 +60,18 @@ fun MainNavHost(
         composable(Screen.Setting.route) { SettingScreen(navController = navController) }
         composable(Screen.PublishPosting.route) { PublishPostingScreen() }
         composable(Screen.CheckPosting.route) { CheckPostingScreen() }
-        composable(Screen.InputStore.route) { InputStoreScreen(navController = navController) }
-        composable(Screen.InputMenu.route) { InputMenuScreen(navController = navController) }
+        composable(Screen.InputStore(isEditMode = true).route) {
+            InputStoreScreen(navController = navController, isEditMode = true)
+        }
+        composable(Screen.InputStore(isEditMode = false).route) {
+            InputStoreScreen(navController = navController, isEditMode = false)
+        }
+        composable(Screen.InputMenu(isEditMode = true).route) {
+            InputMenuScreen(navController = navController, isEditMode = true)
+        }
+        composable(Screen.InputMenu(isEditMode = false).route) {
+            InputMenuScreen(navController = navController, isEditMode = false)
+        }
         composable(Screen.DateTimeListCheck.route) {
             MyCalendarScreen(navController = navController, viewModel = calendarViewModel)
         }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -57,7 +57,7 @@ fun MainNavHost(
 ) {
     NavHost(navController = navController, startDestination = Screen.MAIN.route) {
         composable(Screen.MAIN.route) { MainScreen(navController = navController) }
-        composable(Screen.SETTING.route) { SettingScreen() }
+        composable(Screen.SETTING.route) { SettingScreen(navController = navController) }
         composable(Screen.PUBLISH_POSTING.route) { PublishPostingScreen() }
         composable(Screen.CHECK_POSTING.route) { CheckPostingScreen() }
         composable(Screen.INPUT_STORE.route) { InputStoreScreen(navController = navController) }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -55,23 +55,23 @@ fun MainNavHost(
     navController: NavHostController,
     calendarViewModel: CalendarViewModel,
 ) {
-    NavHost(navController = navController, startDestination = Screen.MAIN.route) {
-        composable(Screen.MAIN.route) { MainScreen(navController = navController) }
-        composable(Screen.SETTING.route) { SettingScreen(navController = navController) }
-        composable(Screen.PUBLISH_POSTING.route) { PublishPostingScreen() }
-        composable(Screen.CHECK_POSTING.route) { CheckPostingScreen() }
-        composable(Screen.INPUT_STORE.route) { InputStoreScreen(navController = navController) }
-        composable(Screen.INPUT_MENU.route) { InputMenuScreen(navController = navController) }
-        composable(Screen.DATE_SELECT.route) {
+    NavHost(navController = navController, startDestination = Screen.Main.route) {
+        composable(Screen.Main.route) { MainScreen(navController = navController) }
+        composable(Screen.Setting.route) { SettingScreen(navController = navController) }
+        composable(Screen.PublishPosting.route) { PublishPostingScreen() }
+        composable(Screen.CheckPosting.route) { CheckPostingScreen() }
+        composable(Screen.InputStore.route) { InputStoreScreen(navController = navController) }
+        composable(Screen.InputMenu.route) { InputMenuScreen(navController = navController) }
+        composable(Screen.DateTimeListCheck.route) {
             MyCalendarScreen(navController = navController, viewModel = calendarViewModel)
         }
-        composable(Screen.TIME_SELECT.route) {
+        composable(Screen.TimeSelect.route) {
             MyScheduleScreen(navController = navController, viewModel = calendarViewModel)
         }
-        composable(Screen.DATE_TIME_LIST_CHECK.route) {
+        composable(Screen.DateTimeListCheck.route) {
             ScheduleListScreen(navController = navController, viewModel = calendarViewModel)
         }
-        composable(Screen.LOGIN.route) { LoginScreen(navController = navController) }
+        composable(Screen.Login.route) { LoginScreen(navController = navController) }
     }
 }
 

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainScreen.kt
@@ -26,7 +26,7 @@ fun MainScreen(navController: NavHostController = rememberNavController()) {
             GsTopAppBar(
                 title = "메인 페이지",
                 hasRightIcon = true,
-                onActionsClick = { navController.navigate(Screen.SETTING.route) },
+                onActionsClick = { navController.navigate(Screen.Setting.route) },
             )
         },
         modifier = Modifier.fillMaxSize(),
@@ -39,12 +39,12 @@ fun MainScreen(navController: NavHostController = rememberNavController()) {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
-            MainButton("글 발행하러 가기") { navController.navigate(Screen.PUBLISH_POSTING.route) }
+            MainButton("글 발행하러 가기") { navController.navigate(Screen.PublishPosting.route) }
 
             Spacer(modifier = Modifier.height(30.dp))
 
-            MainButton("발행 현황 확인하기") { navController.navigate(Screen.CHECK_POSTING.route) }
-            MainButton("기능 확인") { navController.navigate(Screen.DATE_SELECT.route) }
+            MainButton("발행 현황 확인하기") { navController.navigate(Screen.CheckPosting.route) }
+            MainButton("기능 확인") { navController.navigate(Screen.DateSelect.route) }
         }
     }
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
@@ -1,16 +1,25 @@
 package com.erica.gamsung.core.presentation
 
-enum class Screen(
+sealed class Screen(
     val route: String,
 ) {
-    MAIN("main"),
-    SETTING("setting"),
-    PUBLISH_POSTING("publishPosting"),
-    CHECK_POSTING("checkPosting"),
-    INPUT_STORE("inputStore"),
-    INPUT_MENU("inputMenu"),
-    DATE_SELECT("dateSelect"),
-    TIME_SELECT("timeSelect"),
-    DATE_TIME_LIST_CHECK("dateTimeListCheck"),
-    LOGIN("login"),
+    data object Main : Screen("main")
+
+    data object Setting : Screen("setting")
+
+    data object PublishPosting : Screen("publishPosting")
+
+    data object CheckPosting : Screen("checkPosting")
+
+    data object InputStore : Screen("inputStore")
+
+    data object InputMenu : Screen("inputMenu")
+
+    data object DateSelect : Screen("dateSelect")
+
+    data object TimeSelect : Screen("timeSelect")
+
+    data object DateTimeListCheck : Screen("dateTimeListCheck")
+
+    data object Login : Screen("login")
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/Screen.kt
@@ -11,9 +11,13 @@ sealed class Screen(
 
     data object CheckPosting : Screen("checkPosting")
 
-    data object InputStore : Screen("inputStore")
+    data class InputStore(
+        val isEditMode: Boolean,
+    ) : Screen("inputStore/$isEditMode")
 
-    data object InputMenu : Screen("inputMenu")
+    data class InputMenu(
+        val isEditMode: Boolean,
+    ) : Screen("inputMenu/$isEditMode")
 
     data object DateSelect : Screen("dateSelect")
 

--- a/app/src/main/java/com/erica/gamsung/login/presentation/LoginScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/login/presentation/LoginScreen.kt
@@ -119,7 +119,7 @@ private fun InstagramButton(
             if (hasAccount()) {
                 onNavigate(Screen.Main)
             } else {
-                onNavigate(Screen.InputStore)
+                onNavigate(Screen.InputStore(isEditMode = false))
             }
         },
         shape = RoundedCornerShape(50.dp),

--- a/app/src/main/java/com/erica/gamsung/login/presentation/LoginScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/login/presentation/LoginScreen.kt
@@ -117,9 +117,9 @@ private fun InstagramButton(
         onClick = {
             // TODO 인스타 소셜로그인 연결
             if (hasAccount()) {
-                onNavigate(Screen.MAIN)
+                onNavigate(Screen.Main)
             } else {
-                onNavigate(Screen.INPUT_STORE)
+                onNavigate(Screen.InputStore)
             }
         },
         shape = RoundedCornerShape(50.dp),

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -46,13 +46,14 @@ import com.erica.gamsung.menu.domain.Menu
 fun InputMenuScreen(
     navController: NavHostController = rememberNavController(),
     inputMenuViewModel: InputMenuViewModel = hiltViewModel(),
+    isEditMode: Boolean = false,
 ) {
     val menus by inputMenuViewModel.menusState.collectAsState()
     val inputMenuState by inputMenuViewModel.inputMenuState.collectAsState()
     val shouldNavigate by inputMenuViewModel.shouldNavigateState.collectAsState()
 
     Scaffold(
-        topBar = { GsTopAppBar(title = "메뉴 입력 (2/2)") },
+        topBar = { GsTopAppBar(title = if (isEditMode) "메뉴 수정" else "메뉴 입력 (2/2)") },
     ) { paddingValues ->
         Column(
             modifier =
@@ -76,11 +77,11 @@ fun InputMenuScreen(
                         .fillMaxWidth()
                         .height(70.dp)
                         .padding(horizontal = 8.dp, vertical = 12.dp),
-                text = "메뉴 등록하기",
+                text = if (isEditMode) "메뉴 수정하기" else "메뉴 등록하기",
                 onClick = {
                     inputMenuViewModel.onEvent(InputMenuUiEvent.SendMenus)
                     if (shouldNavigate) {
-                        navController.navigate(Screen.MAIN.route)
+                        navController.navigate(Screen.Main.route)
                     }
                 },
             )

--- a/app/src/main/java/com/erica/gamsung/setting/presentation/SettingScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/setting/presentation/SettingScreen.kt
@@ -1,0 +1,98 @@
+package com.erica.gamsung.setting.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.erica.gamsung.core.presentation.component.GsOutlinedButton
+import com.erica.gamsung.core.presentation.component.GsTextButtonWithIcon
+import com.erica.gamsung.core.presentation.component.GsTopAppBar
+
+private val ButtonHeight = 70.dp
+
+@Composable
+fun SettingScreen() {
+    Scaffold(
+        topBar = { GsTopAppBar(title = "마이페이지") },
+    ) { paddingValues ->
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(horizontal = 20.dp),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                StoreSection(modifier = Modifier.weight(2f))
+                Divider()
+                AccountSection(modifier = Modifier.weight(2f))
+                Spacer(modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun StoreSection(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        Text(
+            text = "가게 설정",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        GsTextButtonWithIcon(text = "가게 정보 관리하기", modifier = Modifier.height(ButtonHeight))
+        GsTextButtonWithIcon(text = "메뉴 정보 관리하기", modifier = Modifier.height(ButtonHeight))
+    }
+}
+
+@Composable
+private fun AccountSection(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        Text(
+            text = "계정 설정",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        GsOutlinedButton(
+            text = "로그아웃",
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(ButtonHeight),
+        )
+        GsOutlinedButton(
+            text = "회원 탈퇴",
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(ButtonHeight),
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SettingScreenPreview() {
+    SettingScreen()
+}

--- a/app/src/main/java/com/erica/gamsung/setting/presentation/SettingScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/setting/presentation/SettingScreen.kt
@@ -1,23 +1,29 @@
 package com.erica.gamsung.setting.presentation
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.erica.gamsung.core.presentation.component.GsOutlinedButton
 import com.erica.gamsung.core.presentation.component.GsTextButtonWithIcon
 import com.erica.gamsung.core.presentation.component.GsTopAppBar
 
@@ -74,21 +80,37 @@ private fun AccountSection(modifier: Modifier = Modifier) {
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
         )
-        GsOutlinedButton(
-            text = "로그아웃",
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(ButtonHeight),
-        )
-        GsOutlinedButton(
-            text = "회원 탈퇴",
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(ButtonHeight),
-        )
+
+        AccountButton(text = "로그아웃", onClick = { /* TODO */ })
+        AccountButton(text = "회원탈퇴", onClick = { /* TODO */ })
     }
+}
+
+@Composable
+private fun AccountButton(
+    text: String,
+    onClick: () -> Unit,
+) {
+    OutlinedButton(
+        shape = RoundedCornerShape(10.dp),
+        onClick = onClick,
+        content = {
+            Text(
+                text = text,
+                color = Color.Black,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "KeyboardArrowRight",
+                tint = Color.LightGray,
+            )
+        },
+        colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
+        border = BorderStroke(1.dp, Color.LightGray),
+        modifier = Modifier.height(ButtonHeight),
+    )
 }
 
 @Preview

--- a/app/src/main/java/com/erica/gamsung/setting/presentation/SettingScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/setting/presentation/SettingScreen.kt
@@ -78,12 +78,12 @@ private fun StoreSection(
         GsTextButtonWithIcon(
             text = "가게 정보 관리하기",
             modifier = Modifier.height(ButtonHeight),
-            onClick = { onNavigate(Screen.InputStore) },
+            onClick = { onNavigate(Screen.InputStore(isEditMode = true)) },
         )
         GsTextButtonWithIcon(
             text = "메뉴 정보 관리하기",
             modifier = Modifier.height(ButtonHeight),
-            onClick = { onNavigate(Screen.InputMenu) },
+            onClick = { onNavigate(Screen.InputMenu(isEditMode = true)) },
         )
     }
 }

--- a/app/src/main/java/com/erica/gamsung/setting/presentation/SettingScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/setting/presentation/SettingScreen.kt
@@ -78,12 +78,12 @@ private fun StoreSection(
         GsTextButtonWithIcon(
             text = "가게 정보 관리하기",
             modifier = Modifier.height(ButtonHeight),
-            onClick = { onNavigate(Screen.INPUT_STORE) },
+            onClick = { onNavigate(Screen.InputStore) },
         )
         GsTextButtonWithIcon(
             text = "메뉴 정보 관리하기",
             modifier = Modifier.height(ButtonHeight),
-            onClick = { onNavigate(Screen.INPUT_MENU) },
+            onClick = { onNavigate(Screen.InputMenu) },
         )
     }
 }

--- a/app/src/main/java/com/erica/gamsung/setting/presentation/SettingScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/setting/presentation/SettingScreen.kt
@@ -24,13 +24,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.erica.gamsung.core.presentation.Screen
 import com.erica.gamsung.core.presentation.component.GsTextButtonWithIcon
 import com.erica.gamsung.core.presentation.component.GsTopAppBar
 
 private val ButtonHeight = 70.dp
 
 @Composable
-fun SettingScreen() {
+fun SettingScreen(navController: NavHostController = rememberNavController()) {
     Scaffold(
         topBar = { GsTopAppBar(title = "마이페이지") },
     ) { paddingValues ->
@@ -44,7 +47,12 @@ fun SettingScreen() {
             Column(
                 modifier = Modifier.fillMaxSize(),
             ) {
-                StoreSection(modifier = Modifier.weight(2f))
+                StoreSection(
+                    modifier = Modifier.weight(2f),
+                    onNavigate = { screen ->
+                        navController.navigate(screen.route)
+                    },
+                )
                 Divider()
                 AccountSection(modifier = Modifier.weight(2f))
                 Spacer(modifier = Modifier.weight(1f))
@@ -54,7 +62,10 @@ fun SettingScreen() {
 }
 
 @Composable
-private fun StoreSection(modifier: Modifier = Modifier) {
+private fun StoreSection(
+    modifier: Modifier = Modifier,
+    onNavigate: (Screen) -> Unit,
+) {
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.SpaceEvenly,
@@ -64,8 +75,16 @@ private fun StoreSection(modifier: Modifier = Modifier) {
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
         )
-        GsTextButtonWithIcon(text = "가게 정보 관리하기", modifier = Modifier.height(ButtonHeight))
-        GsTextButtonWithIcon(text = "메뉴 정보 관리하기", modifier = Modifier.height(ButtonHeight))
+        GsTextButtonWithIcon(
+            text = "가게 정보 관리하기",
+            modifier = Modifier.height(ButtonHeight),
+            onClick = { onNavigate(Screen.INPUT_STORE) },
+        )
+        GsTextButtonWithIcon(
+            text = "메뉴 정보 관리하기",
+            modifier = Modifier.height(ButtonHeight),
+            onClick = { onNavigate(Screen.INPUT_MENU) },
+        )
     }
 }
 

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -53,11 +53,12 @@ import java.util.Locale
 fun InputStoreScreen(
     navController: NavHostController = rememberNavController(),
     storeViewModel: StoreViewModel = hiltViewModel(),
+    isEditMode: Boolean = false,
 ) {
     val inputStoreState by storeViewModel.inputStoreState.collectAsState()
 
     Scaffold(
-        topBar = { GsTopAppBar(title = "식당 정보 입력 (1/2)") },
+        topBar = { GsTopAppBar(title = if (isEditMode) "식당 정보 수정" else "식당 정보 입력 (1/2)") },
     ) { paddingValues ->
         Column(
             modifier =
@@ -88,9 +89,10 @@ fun InputStoreScreen(
             RegisterStoreButton(
                 onClick = {
                     storeViewModel.onEvent(InputStoreUiEvent.SendStore)
-                    navController.navigate(Screen.INPUT_MENU.route)
+                    navController.navigate(Screen.InputMenu.route)
                 },
                 enabled = inputStoreState.isValid,
+                isEditMode = isEditMode,
             )
         }
     }
@@ -275,6 +277,7 @@ private fun StorePhoneNumberSection(
 private fun RegisterStoreButton(
     onClick: () -> Unit = {},
     enabled: Boolean = true,
+    isEditMode: Boolean = false,
 ) {
     GsButton(
         modifier =
@@ -282,7 +285,7 @@ private fun RegisterStoreButton(
                 .fillMaxWidth()
                 .height(70.dp)
                 .padding(vertical = 12.dp),
-        text = "가게 등록하기",
+        text = if (isEditMode) "가게 수정하기" else "가게 등록하기",
         onClick = onClick,
         enabled = enabled,
     )

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -89,7 +89,7 @@ fun InputStoreScreen(
             RegisterStoreButton(
                 onClick = {
                     storeViewModel.onEvent(InputStoreUiEvent.SendStore)
-                    navController.navigate(Screen.InputMenu.route)
+                    navController.navigate(Screen.InputMenu(isEditMode = false).route)
                 },
                 enabled = inputStoreState.isValid,
                 isEditMode = isEditMode,


### PR DESCRIPTION
## Issue
- close #21

## Overview (Required)
- 마이 페이지 디자인을 구현한다

## Links
-

## Screenshot
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/683626c2-9bdb-46cf-a74a-354284dc4fa5" width="300" />
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/ae713f0d-4420-49df-acd3-d08b97465581" width="300" />
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/b388c72d-0cf5-40e2-8b22-bc61426ac1c7" width="300" />

---

일단 저번 회의 내용 참고해서 figma의 디자인과 다르게 내 정보 관리와 감성 도움말을 로그아웃과 회원탈퇴로 변경해서 구현했어.

그리고 가게 정보 수정과 메뉴 수정 페이지는 피그마 디자인도 없는 김에 그냥 회원가입 후에 사용하는 초기 입력 페이지들 조금만 바꿔서 사용했어.
지금은 기존의 값들 안 넣어져있는데 기능 구현하는 시점에 기존의 값 넣어져 있도록 수정할게. (#48)

그리고 #4 이슈 닫고 싶은데 #2 참고해서 등록안한 이슈들 등록하고 #4 이슈 닫는거 부탁드립니다.