### PR TITLE
Feature/#52 , #56 뒤로가기 필요한 페이지에 GsTopAppBar 로 뒤로가기 가능한 탑바로 변경 & Navigation Stack 핸들링 하는 코드 삽입

### DIFF
--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -53,7 +53,20 @@ fun InputMenuScreen(
     val shouldNavigate by inputMenuViewModel.shouldNavigateState.collectAsState()
 
     Scaffold(
-        topBar = { GsTopAppBar(title = if (isEditMode) "메뉴 수정" else "메뉴 입력 (2/2)") },
+        topBar = {
+            GsTopAppBar(
+                title = if (isEditMode) "메뉴 수정" else "메뉴 입력 (2/2)",
+                hasLeftIcon = true,
+                onNavigationClick = {
+                    navController.navigate(Screen.Setting.route) {
+                        launchSingleTop = true
+                        popUpTo(Screen.Setting.route) {
+                            inclusive = false
+                        }
+                    }
+                },
+            )
+        },
     ) { paddingValues ->
         Column(
             modifier =
@@ -82,7 +95,12 @@ fun InputMenuScreen(
                     inputMenuViewModel.onEvent(InputMenuUiEvent.SendMenus)
                     if (shouldNavigate) {
                         val toNavigate = if (isEditMode) Screen.Setting else Screen.Main
-                        navController.navigate(toNavigate.route)
+                        navController.navigate(toNavigate.route) {
+                            launchSingleTop = true
+                            popUpTo(toNavigate.route) {
+                                inclusive = false
+                            }
+                        }
                     }
                 },
             )

--- a/app/src/main/java/com/erica/gamsung/post/presentation/PostStatusScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/post/presentation/PostStatusScreen.kt
@@ -40,6 +40,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.erica.gamsung.core.presentation.Screen
+import com.erica.gamsung.core.presentation.component.GsTopAppBar
 import com.erica.gamsung.post.domain.ScheduleState
 import com.erica.gamsung.post.presentation.utils.formatDate
 import com.erica.gamsung.post.presentation.utils.formatTime
@@ -84,7 +85,22 @@ fun PostStatusScreen(
                 else -> true
             }
         } ?: listOf()
-    Scaffold {
+    Scaffold(
+        topBar = {
+            GsTopAppBar(
+                title = "",
+                hasLeftIcon = true,
+                onNavigationClick = {
+                    navController.navigate(Screen.Main.route) {
+                        launchSingleTop = true
+                        popUpTo(navController.graph.startDestinationId) {
+                            inclusive = false
+                        }
+                    }
+                },
+            )
+        },
+    ) {
         Column(
             modifier =
                 Modifier
@@ -93,12 +109,6 @@ fun PostStatusScreen(
                     .fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-//            Spacer(
-//                modifier =
-//                Modifier
-//                    .fillMaxWidth()
-//                    .size(75.dp),
-//            )
             TitleTextSection(text = "발행 중인 글 목록")
             StatusFilterButtons(selectedStatus = selectedStatus) { status ->
                 selectedStatus = status

--- a/app/src/main/java/com/erica/gamsung/post/presentation/PreviewPost.kt
+++ b/app/src/main/java/com/erica/gamsung/post/presentation/PreviewPost.kt
@@ -84,7 +84,11 @@ fun PreviewPost(
         bottomBar = {
             OneButtonSection(
                 modifier = Modifier.padding(vertical = 8.dp),
-                onClick = { navController.navigate(Screen.SelectNewPost.route) },
+                onClick = {
+                    navController.navigate(Screen.SelectNewPost.route) {
+                        launchSingleTop = true
+                    }
+                },
             )
         },
     )

--- a/app/src/main/java/com/erica/gamsung/post/presentation/SelectPostScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/post/presentation/SelectPostScreen.kt
@@ -67,7 +67,7 @@ import kotlin.math.absoluteValue
 @OptIn(
     ExperimentalFoundationApi::class,
 )
-@Suppress("MagicNumber")
+@Suppress("MagicNumber", "LongMethod")
 @Preview
 @Composable
 fun SelectPostScreen(
@@ -82,7 +82,11 @@ fun SelectPostScreen(
     val imgBitmap by postViewModel.imgBitMap.observeAsState()
     val confirmAndNavigate = {
         postViewModel.confirmPostData(reservationId, content, imgBitmap)
-        navController.navigate(Screen.PostsStatus.route)
+        navController.navigate(Screen.PostsStatus.route) {
+            popUpTo(navController.graph.startDestinationId) {
+                inclusive = false
+            }
+        }
     }
     val setContent = { c: String ->
         postViewModel.setContent(c)
@@ -113,7 +117,19 @@ fun SelectPostScreen(
         })
 
     Scaffold(
-        topBar = { GsTopAppBar(title = "글 선택 페이지") },
+        topBar = {
+            GsTopAppBar(
+                title = "글 선택 페이지",
+                hasLeftIcon = true,
+                onNavigationClick = {
+                    navController.navigate(Screen.PostsStatus.route) {
+                        popUpTo(navController.graph.startDestinationId) {
+                            inclusive = false
+                        }
+                    }
+                },
+            )
+        },
         content = { padding ->
             Column(
                 modifier =

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -48,6 +48,7 @@ import java.time.DayOfWeek
 import java.time.format.TextStyle
 import java.util.Locale
 
+@Suppress("LongMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InputStoreScreen(
@@ -58,7 +59,20 @@ fun InputStoreScreen(
     val inputStoreState by storeViewModel.inputStoreState.collectAsState()
 
     Scaffold(
-        topBar = { GsTopAppBar(title = if (isEditMode) "식당 정보 수정" else "식당 정보 입력 (1/2)") },
+        topBar = {
+            GsTopAppBar(
+                title = if (isEditMode) "식당 정보 수정" else "식당 정보 입력 (1/2)",
+                hasLeftIcon = true,
+                onNavigationClick = {
+                    navController.navigate(Screen.Setting.route) {
+                        launchSingleTop = true
+                        popUpTo(Screen.Setting.route) {
+                            inclusive = false
+                        }
+                    }
+                },
+            )
+        },
     ) { paddingValues ->
         Column(
             modifier =
@@ -99,7 +113,12 @@ fun InputStoreScreen(
                 onClick = {
                     storeViewModel.onEvent(InputStoreUiEvent.SendStore)
                     val toNavigate = if (isEditMode) Screen.Setting else Screen.InputMenu(isEditMode = false)
-                    navController.navigate(toNavigate.route)
+                    navController.navigate(toNavigate.route) {
+                        launchSingleTop = true
+                        popUpTo(toNavigate.route) {
+                            inclusive = false
+                        }
+                    }
                 },
                 enabled = inputStoreState.isValid,
                 isEditMode = isEditMode,

--- a/app/src/main/java/com/erica/gamsung/uploadTime/presentation/CalendarScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/uploadTime/presentation/CalendarScreen.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.erica.gamsung.core.presentation.Screen
 import com.erica.gamsung.core.presentation.component.GsButton
+import com.erica.gamsung.core.presentation.component.GsTopAppBar
 
 @Suppress("magicnumber")
 @Preview
@@ -35,7 +37,15 @@ fun MyCalendarScreen(
     // 현재 달에 대한 초기 선택된 날짜 리스트 (예: 오늘)
     // selectedDatesMap[currentMonth] = listOf(LocalDate.now())
 
-    Scaffold {
+    Scaffold(
+        topBar = {
+            GsTopAppBar(
+                title = "날짜 선택",
+                hasLeftIcon = true,
+                onNavigationClick = { navController.navigate(Screen.Main.route) },
+            )
+        },
+    ) {
         Column(
             modifier =
                 Modifier

--- a/app/src/main/java/com/erica/gamsung/uploadTime/presentation/UploadTimeConfirmScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/uploadTime/presentation/UploadTimeConfirmScreen.kt
@@ -41,7 +41,14 @@ fun UploadTimeConfirmScreen(navController: NavHostController = rememberNavContro
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Spacer(modifier = Modifier.weight(1f))
-            ContentSection(modifier = Modifier.weight(2f), onClickEvent = { navController.navigate(Screen.Main.route) })
+            ContentSection(modifier = Modifier.weight(2f), onClickEvent = {
+                navController.navigate(Screen.Main.route) {
+                    launchSingleTop = true
+                    popUpTo(navController.graph.startDestinationId) {
+                        inclusive = true
+                    }
+                }
+            })
             Spacer(modifier = Modifier.weight(1f))
         }
     }


### PR DESCRIPTION
## Issue
- close #67 
- close #52 

## Overview (Required)
- 뒤로가기 가능한 탑바
- 네비게이션 Stack 핸들링(기능마다 비워서 안드로이드 기본 뒤로가기 사용시 네비게이션 그래프의 모든 페이지 되짚지 않고 깔끔하게 앱 꺼지게)

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
