### PR TITLE
Feature/#18 인스타그램 소셜로그인 기능을 구현한다.

### DIFF
--- a/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
+++ b/app/src/androidTest/java/com/erica/gamsung/core/presentation/MainScreenKtTest.kt
@@ -38,6 +38,7 @@ class MainScreenKtTest {
             MainNavHost(
                 navController = navController,
                 scheduleViewModel = viewModel,
+                startScreen = Screen.Main,
             )
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,10 +21,22 @@
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Gamsung.Splash">
+            <tools:validation testUrl="https://gamsung.shop/android" />
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="gamsung.shop" />
+                <data android:pathPattern="/android" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/erica/gamsung/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/erica/gamsung/core/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.erica.gamsung.core.di
 
 import com.erica.gamsung.BuildConfig
+import com.erica.gamsung.login.data.remote.LoginApi
 import com.erica.gamsung.menu.data.remote.MenuApi
 import com.erica.gamsung.post.data.remote.PostApi
 import com.erica.gamsung.store.data.remote.StoreApi
@@ -96,4 +97,8 @@ object NetworkModule {
     @Singleton
     @Provides
     fun provideScheduleService(retrofit: Retrofit): ScheduleApi = retrofit.create(ScheduleApi::class.java)
+
+    @Singleton
+    @Provides
+    fun provideLoginApi(retrofit: Retrofit): LoginApi = retrofit.create(LoginApi::class.java)
 }

--- a/app/src/main/java/com/erica/gamsung/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/erica/gamsung/core/di/RepositoryModule.kt
@@ -1,5 +1,9 @@
 package com.erica.gamsung.core.di
 
+import android.content.Context
+import com.erica.gamsung.login.data.remote.LoginApi
+import com.erica.gamsung.login.data.repository.LoginRepositoryImpl
+import com.erica.gamsung.login.domain.LoginRepository
 import com.erica.gamsung.menu.data.local.MenuDao
 import com.erica.gamsung.menu.data.remote.MenuApi
 import com.erica.gamsung.menu.data.repository.MenuRepositoryImpl
@@ -11,6 +15,7 @@ import com.erica.gamsung.store.domain.StoreRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -30,4 +35,11 @@ object RepositoryModule {
         storeDao: StoreDao,
         storeApi: StoreApi,
     ): StoreRepository = StoreRepositoryImpl(storeDao = storeDao, storeApi = storeApi)
+
+    @Singleton
+    @Provides
+    fun provideLoginRepository(
+        loginApi: LoginApi,
+        @ApplicationContext context: Context,
+    ): LoginRepository = LoginRepositoryImpl(loginApi = loginApi, context = context)
 }

--- a/app/src/main/java/com/erica/gamsung/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/erica/gamsung/core/di/RepositoryModule.kt
@@ -40,6 +40,14 @@ object RepositoryModule {
     @Provides
     fun provideLoginRepository(
         loginApi: LoginApi,
+        menuApi: MenuApi,
+        storeApi: StoreApi,
         @ApplicationContext context: Context,
-    ): LoginRepository = LoginRepositoryImpl(loginApi = loginApi, context = context)
+    ): LoginRepository =
+        LoginRepositoryImpl(
+            loginApi = loginApi,
+            menuApi = menuApi,
+            storeApi = storeApi,
+            context = context,
+        )
 }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -80,7 +80,7 @@ class MainActivity : ComponentActivity() {
                     if (hasAccount) {
                         navController.navigate(Screen.Main.route)
                     } else {
-                        navController.navigate(Screen.InputMenu(isEditMode = false).route)
+                        navController.navigate(Screen.InputStore(isEditMode = false).route)
                     }
                 }
             }

--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -59,6 +59,7 @@ class MainActivity : ComponentActivity() {
                     MainNavHost(
                         navController = navController,
                         scheduleViewModel = scheduleViewModel,
+                        startScreen = if (loginViewModel.isLogin()) Screen.Main else Screen.Login,
                     )
                 }
             }
@@ -78,9 +79,13 @@ class MainActivity : ComponentActivity() {
             if (uri.toString().startsWith("https://gamsung.shop/android")) {
                 loginViewModel.fetchAccessToken { hasAccount ->
                     if (hasAccount) {
-                        navController.navigate(Screen.Main.route)
+                        navController.navigate(Screen.Main.route) {
+                            popUpTo(Screen.Login.route) { inclusive = true }
+                        }
                     } else {
-                        navController.navigate(Screen.InputStore(isEditMode = false).route)
+                        navController.navigate(Screen.InputStore(isEditMode = false).route) {
+                            popUpTo(Screen.Login.route) { inclusive = true }
+                        }
                     }
                 }
             }
@@ -92,10 +97,11 @@ class MainActivity : ComponentActivity() {
 fun MainNavHost(
     navController: NavHostController,
     scheduleViewModel: ScheduleViewModel,
+    startScreen: Screen,
 ) {
     val postViewModel: PostViewModel = hiltViewModel()
     val inputMenuViewModel: InputMenuViewModel = hiltViewModel()
-    NavHost(navController = navController, startDestination = Screen.Login.route) {
+    NavHost(navController = navController, startDestination = startScreen.route) {
         composable(Screen.Main.route) {
             MainScreen(navController = navController)
             LogNavStack(navController = navController)

--- a/app/src/main/java/com/erica/gamsung/login/data/remote/LoginApi.kt
+++ b/app/src/main/java/com/erica/gamsung/login/data/remote/LoginApi.kt
@@ -1,0 +1,16 @@
+package com.erica.gamsung.login.data.remote
+
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface LoginApi {
+    @GET("oauth2/get/{uuid}")
+    suspend fun getToken(
+        @Path("uuid") uuid: String,
+    ): TokenResponse
+}
+
+data class TokenResponse(
+    val providerId: Long,
+    val accessToken: String,
+)

--- a/app/src/main/java/com/erica/gamsung/login/data/repository/LoginRepositoryImpl.kt
+++ b/app/src/main/java/com/erica/gamsung/login/data/repository/LoginRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package com.erica.gamsung.login.data.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.erica.gamsung.login.data.remote.LoginApi
+import com.erica.gamsung.login.domain.LoginRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+
+class LoginRepositoryImpl(
+    private val loginApi: LoginApi,
+    @ApplicationContext private val context: Context,
+) : LoginRepository {
+    private val sharedPreferences: SharedPreferences = context.getSharedPreferences("prefs", Context.MODE_PRIVATE)
+
+    override suspend fun fetchAccessToken(uuid: String): String {
+        val accessToken = loginApi.getToken(uuid).accessToken
+        saveToken(accessToken)
+        return accessToken
+    }
+
+    override fun getSavedAccessToken(): String? = sharedPreferences.getString("access_token", null)
+
+    override fun saveUUID(uuid: String) {
+        sharedPreferences.edit().putString("uuid", uuid).apply()
+    }
+
+    override fun getSavedUUID(): String? = sharedPreferences.getString("uuid", null)
+
+    private fun saveToken(token: String) {
+        sharedPreferences.edit().putString("access_token", token).apply()
+    }
+}

--- a/app/src/main/java/com/erica/gamsung/login/data/repository/LoginRepositoryImpl.kt
+++ b/app/src/main/java/com/erica/gamsung/login/data/repository/LoginRepositoryImpl.kt
@@ -4,10 +4,16 @@ import android.content.Context
 import android.content.SharedPreferences
 import com.erica.gamsung.login.data.remote.LoginApi
 import com.erica.gamsung.login.domain.LoginRepository
+import com.erica.gamsung.menu.data.remote.MenuApi
+import com.erica.gamsung.store.data.remote.StoreApi
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 
 class LoginRepositoryImpl(
     private val loginApi: LoginApi,
+    private val menuApi: MenuApi,
+    private val storeApi: StoreApi,
     @ApplicationContext private val context: Context,
 ) : LoginRepository {
     private val sharedPreferences: SharedPreferences = context.getSharedPreferences("prefs", Context.MODE_PRIVATE)
@@ -25,6 +31,14 @@ class LoginRepositoryImpl(
     }
 
     override fun getSavedUUID(): String? = sharedPreferences.getString("uuid", null)
+
+    override suspend fun hasAccount(): Boolean =
+        coroutineScope {
+            val menuResult = async { runCatching { menuApi.getMenus() }.isSuccess }
+            val storeResult = async { runCatching { storeApi.getStore() }.isSuccess }
+
+            menuResult.await() && storeResult.await()
+        }
 
     private fun saveToken(token: String) {
         sharedPreferences.edit().putString("access_token", token).apply()

--- a/app/src/main/java/com/erica/gamsung/login/domain/LoginRepository.kt
+++ b/app/src/main/java/com/erica/gamsung/login/domain/LoginRepository.kt
@@ -1,0 +1,11 @@
+package com.erica.gamsung.login.domain
+
+interface LoginRepository {
+    suspend fun fetchAccessToken(uuid: String): String
+
+    fun getSavedAccessToken(): String?
+
+    fun saveUUID(uuid: String)
+
+    fun getSavedUUID(): String?
+}

--- a/app/src/main/java/com/erica/gamsung/login/domain/LoginRepository.kt
+++ b/app/src/main/java/com/erica/gamsung/login/domain/LoginRepository.kt
@@ -8,4 +8,6 @@ interface LoginRepository {
     fun saveUUID(uuid: String)
 
     fun getSavedUUID(): String?
+
+    suspend fun hasAccount(): Boolean
 }

--- a/app/src/main/java/com/erica/gamsung/login/presentation/LoginScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/login/presentation/LoginScreen.kt
@@ -1,5 +1,7 @@
 package com.erica.gamsung.login.presentation
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -29,15 +32,13 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.erica.gamsung.R
-import com.erica.gamsung.core.presentation.Screen
 import com.erica.gamsung.core.presentation.theme.LIGHT_PINK
 import com.erica.gamsung.core.presentation.theme.VividBlue
 
 @Composable
-fun LoginScreen(navController: NavHostController = rememberNavController()) {
+fun LoginScreen(loginViewModel: LoginViewModel = hiltViewModel()) {
     Box(
         modifier =
             Modifier
@@ -56,10 +57,7 @@ fun LoginScreen(navController: NavHostController = rememberNavController()) {
             TitleSection(modifier = Modifier.weight(1f))
             LoginButtonSection(
                 modifier = Modifier.weight(1f),
-                onNavigate = { screen ->
-                    navController.navigate(screen.route)
-                },
-                hasAccount = { true },
+                loginViewModel = loginViewModel,
             )
         }
     }
@@ -94,8 +92,7 @@ private fun TitleSection(modifier: Modifier = Modifier) {
 @Composable
 private fun LoginButtonSection(
     modifier: Modifier = Modifier,
-    onNavigate: (Screen) -> Unit = {},
-    hasAccount: () -> Boolean = { true },
+    loginViewModel: LoginViewModel,
 ) {
     Column(
         modifier = modifier,
@@ -104,23 +101,22 @@ private fun LoginButtonSection(
     ) {
         Text(text = "3초만에 시작하기", style = MaterialTheme.typography.labelMedium)
         Divider(modifier = Modifier.padding(vertical = 8.dp))
-        InstagramButton(onNavigate = onNavigate, hasAccount = hasAccount)
+        InstagramButton(loginViewModel = loginViewModel)
     }
 }
 
 @Composable
-private fun InstagramButton(
-    onNavigate: (Screen) -> Unit = {},
-    hasAccount: () -> Boolean = { true },
-) {
+private fun InstagramButton(loginViewModel: LoginViewModel) {
+    val ctx = LocalContext.current
     Button(
         onClick = {
-            // TODO 인스타 소셜로그인 연결
-            if (hasAccount()) {
-                onNavigate(Screen.Main)
-            } else {
-                onNavigate(Screen.InputStore(isEditMode = false))
-            }
+            val oAuthUrl = loginViewModel.getLoginUrl()
+            val urlIntent =
+                Intent(
+                    Intent.ACTION_VIEW,
+                    Uri.parse(oAuthUrl),
+                )
+            ctx.startActivity(urlIntent)
         },
         shape = RoundedCornerShape(50.dp),
         colors =

--- a/app/src/main/java/com/erica/gamsung/login/presentation/LoginViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/login/presentation/LoginViewModel.kt
@@ -1,0 +1,39 @@
+package com.erica.gamsung.login.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.erica.gamsung.login.domain.LoginRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel
+    @Inject
+    constructor(
+        private val loginRepository: LoginRepository,
+    ) : ViewModel() {
+        fun getLoginUrl(): String {
+            val uuid = UUID.randomUUID().toString()
+            loginRepository.saveUUID(uuid)
+            return "https://gamsung.shop/oauth2/authorization/facebook?uuid=$uuid"
+        }
+
+        fun fetchAccessToken(onTokenReceived: (Boolean) -> Unit) {
+            viewModelScope.launch {
+                val uuid = loginRepository.getSavedUUID()
+                uuid?.let {
+                    loginRepository.fetchAccessToken(it)
+//                    val hasAccount = checkIfUserHasAccount(accessToken)
+                    val hasAccount = true
+                    onTokenReceived(hasAccount)
+                }
+            }
+        }
+
+//        private fun checkIfUserHasAccount(accessToken: String): Boolean {
+//            // TODO
+//            return true
+//        }
+    }

--- a/app/src/main/java/com/erica/gamsung/login/presentation/LoginViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/login/presentation/LoginViewModel.kt
@@ -25,15 +25,9 @@ class LoginViewModel
                 val uuid = loginRepository.getSavedUUID()
                 uuid?.let {
                     loginRepository.fetchAccessToken(it)
-//                    val hasAccount = checkIfUserHasAccount(accessToken)
-                    val hasAccount = true
+                    val hasAccount = loginRepository.hasAccount()
                     onTokenReceived(hasAccount)
                 }
             }
         }
-
-//        private fun checkIfUserHasAccount(accessToken: String): Boolean {
-//            // TODO
-//            return true
-//        }
     }

--- a/app/src/main/java/com/erica/gamsung/login/presentation/LoginViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/login/presentation/LoginViewModel.kt
@@ -30,4 +30,6 @@ class LoginViewModel
                 }
             }
         }
+
+        fun isLogin(): Boolean = loginRepository.getSavedAccessToken() != null
     }


### PR DESCRIPTION
## Issue
- close #18 

## Overview (Required)
- 인스타그램(페이스북 비즈니스) 소셜로그인 기능을 구현한다.
- 소셜로그인 이후에 앱링크를 통해 앱으로 복귀한다.
- 스플래시 이후 로그인이 되어있으면 메인 페이지로 이동한다.
- 스플래시 이후 로그인이 안되어있으면 로그인 페이지로 이동한다.
- 로그인 이후 가게 정보 및 메뉴 정보가 하나라도 입력이 안되어있으면 가게 정보 입력 페이지로 이동한다.
- 로그인 이후 가게 정보 및 메뉴 정보가 모두 입력이 되어있으면 메인 페이지로 이동한다.

## Links
- [앱 링크 적용](https://onlyfor-me-blog.tistory.com/872)
- [SharedPreference](https://velog.io/@ilil1/%EA%B0%9C%EB%85%90-SharedPreference-%EC%95%8C%EC%95%84%EB%B3%B4%EA%B8%B0)

## Screenshot
<img src="https://github.com/ERICA-gamsung/android/assets/55042337/0297984c-d529-4467-924f-1ec83f3e4256" width="300" />

---

사실상 인스타그램 소셜로그인은 아니고 페이스북 비즈니스 로그인인데
위 사진처럼 현재는 로그인 버튼 디자인이 인스타그램으로 되어있어.
이거 페이스북으로 수정할까?? 

그리고 서버 API에 토큰 통해서 유저 식별할 수 있게 구현되면 이 부분에 맞게 앱에서 서버에 요청해야 하고 #76 
소셜로그인 이후에 앱 복귀 시에 스플래시 한 번 더 뜨는 버그 있어서 이 부분 이슈 추가해놨어. #77 