### PR TITLE
Feature/#79 가게 및 메뉴 입력 화면에서 뒤로 가기 시 설정 화면으로 이동하는 버그를 수정한다

### DIFF
--- a/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/erica/gamsung/core/presentation/MainActivity.kt
@@ -23,7 +23,7 @@ import com.erica.gamsung.core.presentation.theme.GamsungTheme
 import com.erica.gamsung.login.presentation.LoginScreen
 import com.erica.gamsung.login.presentation.LoginViewModel
 import com.erica.gamsung.menu.presentation.InputMenuScreen
-import com.erica.gamsung.menu.presentation.InputMenuViewModel
+import com.erica.gamsung.menu.presentation.MenuViewModel
 import com.erica.gamsung.post.presentation.PostStatusScreen
 import com.erica.gamsung.post.presentation.PostViewModel
 import com.erica.gamsung.post.presentation.PreviewPost
@@ -100,7 +100,7 @@ fun MainNavHost(
     startScreen: Screen,
 ) {
     val postViewModel: PostViewModel = hiltViewModel()
-    val inputMenuViewModel: InputMenuViewModel = hiltViewModel()
+    val menuViewModel: MenuViewModel = hiltViewModel()
     NavHost(navController = navController, startDestination = startScreen.route) {
         composable(Screen.Main.route) {
             MainScreen(navController = navController, postViewModel)
@@ -116,10 +116,10 @@ fun MainNavHost(
             InputStoreScreen(navController = navController, isEditMode = false)
         }
         composable(Screen.InputMenu(isEditMode = true).route) {
-            InputMenuScreen(navController = navController, isEditMode = true, inputMenuViewModel = inputMenuViewModel)
+            InputMenuScreen(navController = navController, isEditMode = true, menuViewModel = menuViewModel)
         }
         composable(Screen.InputMenu(isEditMode = false).route) {
-            InputMenuScreen(navController = navController, isEditMode = false, inputMenuViewModel = inputMenuViewModel)
+            InputMenuScreen(navController = navController, isEditMode = false, menuViewModel = menuViewModel)
         }
         composable(Screen.DateSelect.route) {
             MyCalendarScreen(navController = navController, viewModel = scheduleViewModel)
@@ -129,7 +129,7 @@ fun MainNavHost(
             MyScheduleScreen(
                 navController = navController,
                 viewModel = scheduleViewModel,
-                menuViewModel = inputMenuViewModel,
+                menuViewModel = menuViewModel,
             )
             LogNavStack(navController = navController)
         }

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -58,9 +58,10 @@ fun InputMenuScreen(
                 title = if (isEditMode) "메뉴 수정" else "메뉴 입력 (2/2)",
                 hasLeftIcon = true,
                 onNavigationClick = {
-                    navController.navigate(Screen.Setting.route) {
+                    val toNavigate = if (isEditMode) Screen.Setting else Screen.InputStore(isEditMode = false)
+                    navController.navigate(toNavigate.route) {
                         launchSingleTop = true
-                        popUpTo(Screen.Setting.route) {
+                        popUpTo(toNavigate.route) {
                             inclusive = false
                         }
                     }

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -42,6 +42,7 @@ import com.erica.gamsung.core.presentation.component.InputTextBox
 import com.erica.gamsung.core.presentation.component.TextTitle
 import com.erica.gamsung.menu.domain.Menu
 
+@Suppress("LongMethod")
 @Composable
 fun InputMenuScreen(
     navController: NavHostController = rememberNavController(),

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/InputMenuScreen.kt
@@ -45,12 +45,12 @@ import com.erica.gamsung.menu.domain.Menu
 @Composable
 fun InputMenuScreen(
     navController: NavHostController = rememberNavController(),
-    inputMenuViewModel: InputMenuViewModel = hiltViewModel(),
+    menuViewModel: MenuViewModel = hiltViewModel(),
     isEditMode: Boolean = false,
 ) {
-    val menus by inputMenuViewModel.menusState.collectAsState()
-    val inputMenuState by inputMenuViewModel.inputMenuState.collectAsState()
-    val shouldNavigate by inputMenuViewModel.shouldNavigateState.collectAsState()
+    val menus by menuViewModel.menusState.collectAsState()
+    val inputMenuState by menuViewModel.inputMenuState.collectAsState()
+    val shouldNavigate by menuViewModel.shouldNavigateState.collectAsState()
 
     Scaffold(
         topBar = {
@@ -82,7 +82,7 @@ fun InputMenuScreen(
                         .fillMaxWidth()
                         .weight(1f),
             ) {
-                InputMenuSection(menus, inputMenuState, inputMenuViewModel)
+                InputMenuSection(menus, inputMenuState, menuViewModel)
             }
             Divider()
             GsButton(
@@ -93,7 +93,7 @@ fun InputMenuScreen(
                         .padding(horizontal = 8.dp, vertical = 12.dp),
                 text = if (isEditMode) "메뉴 수정하기" else "메뉴 등록하기",
                 onClick = {
-                    inputMenuViewModel.onEvent(InputMenuUiEvent.SendMenus)
+                    menuViewModel.onEvent(InputMenuUiEvent.SendMenus)
                     if (shouldNavigate) {
                         val toNavigate = if (isEditMode) Screen.Setting else Screen.Main
                         navController.navigate(toNavigate.route) {
@@ -113,7 +113,7 @@ fun InputMenuScreen(
 private fun InputMenuSection(
     menus: List<Menu>,
     inputMenuState: InputMenuState,
-    inputMenuViewModel: InputMenuViewModel,
+    menuViewModel: MenuViewModel,
 ) {
     LazyColumn(
         modifier =
@@ -125,7 +125,7 @@ private fun InputMenuSection(
         verticalArrangement = Arrangement.Top,
     ) {
         itemsIndexed(menus) { index, menu ->
-            CompletedMenuItem(menu) { inputMenuViewModel.onEvent(InputMenuUiEvent.RemoveMenu(index)) }
+            CompletedMenuItem(menu) { menuViewModel.onEvent(InputMenuUiEvent.RemoveMenu(index)) }
         }
 
         item {
@@ -133,10 +133,10 @@ private fun InputMenuSection(
                 name = inputMenuState.name,
                 price = inputMenuState.price,
                 nameChanged = {
-                    inputMenuViewModel.onEvent(InputMenuUiEvent.NameChanged(it))
+                    menuViewModel.onEvent(InputMenuUiEvent.NameChanged(it))
                 },
                 priceChanged = {
-                    inputMenuViewModel.onEvent(InputMenuUiEvent.PriceChanged(it))
+                    menuViewModel.onEvent(InputMenuUiEvent.PriceChanged(it))
                 },
                 isNameValid = inputMenuState.isNameValid,
                 isPriceValid = inputMenuState.isPriceValid,
@@ -145,7 +145,7 @@ private fun InputMenuSection(
 
         item {
             IconButton(onClick = {
-                inputMenuViewModel.onEvent(InputMenuUiEvent.AddMenu)
+                menuViewModel.onEvent(InputMenuUiEvent.AddMenu)
             }) {
                 Icon(
                     imageVector = Icons.Default.AddCircleOutline,

--- a/app/src/main/java/com/erica/gamsung/menu/presentation/MenuViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/menu/presentation/MenuViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class InputMenuViewModel
+class MenuViewModel
     @Inject
     constructor(
         state: SavedStateHandle,

--- a/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/store/presentation/InputStoreScreen.kt
@@ -62,7 +62,7 @@ fun InputStoreScreen(
         topBar = {
             GsTopAppBar(
                 title = if (isEditMode) "식당 정보 수정" else "식당 정보 입력 (1/2)",
-                hasLeftIcon = true,
+                hasLeftIcon = isEditMode,
                 onNavigationClick = {
                     navController.navigate(Screen.Setting.route) {
                         launchSingleTop = true

--- a/app/src/main/java/com/erica/gamsung/uploadTime/presentation/ScheduleScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/uploadTime/presentation/ScheduleScreen.kt
@@ -48,7 +48,7 @@ import com.erica.gamsung.core.presentation.component.GsButton
 import com.erica.gamsung.core.presentation.component.GsOutlinedButton
 import com.erica.gamsung.core.presentation.component.TextTitle
 import com.erica.gamsung.core.presentation.component.TimeInputBox
-import com.erica.gamsung.menu.presentation.InputMenuViewModel
+import com.erica.gamsung.menu.presentation.MenuViewModel
 import com.erica.gamsung.store.presentation.utils.toDisplayString
 import com.erica.gamsung.uploadTime.presentation.component.CustomInputTextBox
 
@@ -58,7 +58,7 @@ import com.erica.gamsung.uploadTime.presentation.component.CustomInputTextBox
 fun MyScheduleScreen(
     navController: NavHostController,
     viewModel: ScheduleViewModel = viewModel(),
-    menuViewModel: InputMenuViewModel = viewModel(),
+    menuViewModel: MenuViewModel = viewModel(),
 ) {
     BackHandler(enabled = true) {
 //

--- a/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
+++ b/app/src/test/java/com/erica/gamsung/menu/presentation/InputMenuViewModelTest.kt
@@ -13,7 +13,7 @@ class InputMenuViewModelTest :
         context("NameChanged 이벤트를 발생시켰을 때") {
             test("추가할 메뉴명을 수정할 수 있다.") {
                 // Given
-                val viewModel = InputMenuViewModel(SavedStateHandle())
+                val viewModel = MenuViewModel(SavedStateHandle())
 
                 // When
                 viewModel.onEvent(InputMenuUiEvent.NameChanged("새 메뉴"))
@@ -27,7 +27,7 @@ class InputMenuViewModelTest :
         context("PriceChanged 이벤트를 발생시켰을 때") {
             test("추가할 메뉴명을 수정할 수 있다.") {
                 // Given
-                val viewModel = InputMenuViewModel(SavedStateHandle())
+                val viewModel = MenuViewModel(SavedStateHandle())
 
                 // When
                 viewModel.onEvent(InputMenuUiEvent.PriceChanged("3000"))
@@ -42,8 +42,8 @@ class InputMenuViewModelTest :
             test("메뉴를 추가할 수 있다.") {
                 // Given
                 val initialInputMenuState = InputMenuState("새 메뉴", "3000")
-                val initialState = mapOf(InputMenuViewModel.INPUT_MENU to initialInputMenuState)
-                val viewModel = InputMenuViewModel(SavedStateHandle(initialState))
+                val initialState = mapOf(MenuViewModel.INPUT_MENU to initialInputMenuState)
+                val viewModel = MenuViewModel(SavedStateHandle(initialState))
 
                 // When
                 viewModel.onEvent(InputMenuUiEvent.AddMenu)
@@ -57,8 +57,8 @@ class InputMenuViewModelTest :
             test("메뉴명이 공백이거나 비어있으면 메뉴를 추가할 수 없다") {
                 // Given
                 val initialInputMenuState = InputMenuState(" ", "3000")
-                val initialState = mapOf(InputMenuViewModel.INPUT_MENU to initialInputMenuState)
-                val viewModel = InputMenuViewModel(SavedStateHandle(initialState))
+                val initialState = mapOf(MenuViewModel.INPUT_MENU to initialInputMenuState)
+                val viewModel = MenuViewModel(SavedStateHandle(initialState))
 
                 // When
                 viewModel.onEvent(InputMenuUiEvent.AddMenu)
@@ -71,8 +71,8 @@ class InputMenuViewModelTest :
             test("가격이 숫자가 아니면 메뉴를 추가할 수 없다") {
                 // Given
                 val initialInputMenuState = InputMenuState("새 메뉴", "삼천원")
-                val initialState = mapOf(InputMenuViewModel.INPUT_MENU to initialInputMenuState)
-                val viewModel = InputMenuViewModel(SavedStateHandle(initialState))
+                val initialState = mapOf(MenuViewModel.INPUT_MENU to initialInputMenuState)
+                val viewModel = MenuViewModel(SavedStateHandle(initialState))
 
                 // When
                 viewModel.onEvent(InputMenuUiEvent.AddMenu)
@@ -85,8 +85,8 @@ class InputMenuViewModelTest :
             test("가격이 음수면 메뉴를 추가할 수 없다") {
                 // Given
                 val initialInputMenuState = InputMenuState("새 메뉴", "-3000")
-                val initialState = mapOf(InputMenuViewModel.INPUT_MENU to initialInputMenuState)
-                val viewModel = InputMenuViewModel(SavedStateHandle(initialState))
+                val initialState = mapOf(MenuViewModel.INPUT_MENU to initialInputMenuState)
+                val viewModel = MenuViewModel(SavedStateHandle(initialState))
 
                 // When
                 viewModel.onEvent(InputMenuUiEvent.AddMenu)
@@ -99,8 +99,8 @@ class InputMenuViewModelTest :
             test("메뉴 추가 후에 추가할 메뉴명과 추가할 가격은 빈 문자열로 초기화된다.") {
                 // Given
                 val initialInputMenuState = InputMenuState("새 메뉴", "3000")
-                val initialState = mapOf(InputMenuViewModel.INPUT_MENU to initialInputMenuState)
-                val viewModel = InputMenuViewModel(SavedStateHandle(initialState))
+                val initialState = mapOf(MenuViewModel.INPUT_MENU to initialInputMenuState)
+                val viewModel = MenuViewModel(SavedStateHandle(initialState))
 
                 // When
                 viewModel.onEvent(InputMenuUiEvent.AddMenu)
@@ -122,8 +122,8 @@ class InputMenuViewModelTest :
                         Menu("메뉴2", 2000),
                         Menu("메뉴3", 3000),
                     )
-                val initialState = mapOf(InputMenuViewModel.MENUS to initialMenus)
-                val viewModel = InputMenuViewModel(SavedStateHandle(initialState))
+                val initialState = mapOf(MenuViewModel.MENUS to initialMenus)
+                val viewModel = MenuViewModel(SavedStateHandle(initialState))
 
                 // When
                 viewModel.onEvent(InputMenuUiEvent.RemoveMenu(1))
@@ -143,8 +143,8 @@ class InputMenuViewModelTest :
             test("입력된 메뉴가 하나도 없을 시 메인 페이지로 이동하면 안된다.") {
                 // Given
                 val initialMenus = emptyList<Menu>()
-                val initialState = mapOf(InputMenuViewModel.MENUS to initialMenus)
-                val viewModel = InputMenuViewModel(SavedStateHandle(initialState))
+                val initialState = mapOf(MenuViewModel.MENUS to initialMenus)
+                val viewModel = MenuViewModel(SavedStateHandle(initialState))
 
                 // When
                 viewModel.onEvent(InputMenuUiEvent.SendMenus)
@@ -157,8 +157,8 @@ class InputMenuViewModelTest :
             test("입력된 메뉴가 하나도 없을 시 메뉴와 가격을 입력하라고 표시된다.") {
                 // Given
                 val initialMenus = emptyList<Menu>()
-                val initialState = mapOf(InputMenuViewModel.MENUS to initialMenus)
-                val viewModel = InputMenuViewModel(SavedStateHandle(initialState))
+                val initialState = mapOf(MenuViewModel.MENUS to initialMenus)
+                val viewModel = MenuViewModel(SavedStateHandle(initialState))
 
                 // When
                 viewModel.onEvent(InputMenuUiEvent.SendMenus)
@@ -173,8 +173,8 @@ class InputMenuViewModelTest :
             test("입력된 메뉴가 한 개 이상이면 메인 페이지로 이동해도 된다.") {
                 // Given
                 val initialMenus = listOf(Menu("입력된 메뉴", 1000))
-                val initialState = mapOf(InputMenuViewModel.MENUS to initialMenus)
-                val viewModel = InputMenuViewModel(SavedStateHandle(initialState))
+                val initialState = mapOf(MenuViewModel.MENUS to initialMenus)
+                val viewModel = MenuViewModel(SavedStateHandle(initialState))
 
                 // When
                 viewModel.onEvent(InputMenuUiEvent.SendMenus)


### PR DESCRIPTION
## Issue
- close #79 

## Overview (Required)
- 가게 및 메뉴 입력 화면에서 뒤로 가기 시 설정 화면으로 이동하는 버그를 수정한다
- `InputMenuViewModel` -> `MenuViewModel` 이름 변경 

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
