### PR TITLE
Fix: SelectPostScreen PreviewPost 이동에서 선택했던 이미지 view에서 보여지는 것 수정

### DIFF
--- a/app/src/main/java/com/erica/gamsung/post/presentation/SelectPostScreen.kt
+++ b/app/src/main/java/com/erica/gamsung/post/presentation/SelectPostScreen.kt
@@ -257,23 +257,22 @@ fun PicSection(
                 .clickable { imagePickerLauncher.launch("image/*") },
         contentAlignment = Alignment.Center,
     ) {
-        if (selectedImageUri.value == null) {
+        if (imgBitmap == null) {
             Button(onClick = { imagePickerLauncher.launch("image/*") }) {
                 Text("사진 업로드")
             }
         } else {
-            imgBitmap?.let {
-                Image(
-                    bitmap = it.asImageBitmap(),
-                    contentDescription = "Selected Image",
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop,
-                )
-            } ?: run {
-                Button(onClick = { imagePickerLauncher.launch("image/*") }) {
-                    Text("사진 업로드")
-                }
-            }
+            Image(
+                bitmap = imgBitmap.asImageBitmap(),
+                contentDescription = "Selected Image",
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+            )
+//            ) ?: run {
+//                Button(onClick = { imagePickerLauncher.launch("image/*") }) {
+//                    Text("사진 업로드")
+//                }
+//            }
         }
     }
 }


### PR DESCRIPTION
## Issue
- close #90 

## Overview (Required)
- SelectPostScreen <-> PreviewPost 간 이동시 각 이미지 view에서 동일한 사진 view가 나오게 수정

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="
![image](https://github.com/ERICA-gamsung/android/assets/55565839/e4294a82-2380-4f18-a43c-c0715c30ab45)
" width="300" /> | <img src="
![image](https://github.com/ERICA-gamsung/android/assets/55565839/682d0ca4-6c1a-4f65-ab6f-5808dd6aa724)
" width="300" />
![image](https://github.com/ERICA-gamsung/android/assets/55565839/44a1dfd6-98c1-4999-b105-1dfa40df1ca1)
