### PR TITLE
Feature #92 글 확정 API 호출 후에 인스타그램에 업로드 되지 않던 버그를 수정한다

### DIFF
--- a/app/src/main/java/com/erica/gamsung/post/presentation/PostViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/post/presentation/PostViewModel.kt
@@ -124,14 +124,13 @@ class PostViewModel
             viewModelScope.launch {
                 try {
                     reservationId?.let { resId ->
-                        postApi.confirmPostData(resId, Post(content))
                         imgBitmap?.let {
                             val imgByte = bitmapToByteArray(it)
+                            val requestBody = imgByte.toRequestBody("image/jpeg".toMediaTypeOrNull())
+                            val formData = MultipartBody.Part.createFormData("files", "image.jpg", requestBody)
+                            val filesList = listOf(formData)
+                            val response = postApi.confirmImgData(resId, filesList)
                             if (imgByte.isNotEmpty()) {
-                                val requestBody = imgByte.toRequestBody("image/jpeg".toMediaTypeOrNull())
-                                val formData = MultipartBody.Part.createFormData("files", "image.jpg", requestBody)
-                                val filesList = listOf(formData)
-                                val response = postApi.confirmImgData(resId, filesList)
                                 if (response.isSuccessful) {
                                     val responseBody = response.body()
                                     Log.d("ViewModel", "Image upload successful: $responseBody")
@@ -141,6 +140,7 @@ class PostViewModel
                             } else {
                                 Log.e("ViewModel", "Image byte array is empty, skipping upload")
                             }
+                            postApi.confirmPostData(resId, Post(content))
                         } ?: Log.e("ViewModel", "Image Bitmap is null, skipping upload")
                     } ?: Log.e("ViewModel", "Reservation ID is null, cannot upload data")
                 } catch (e: IOException) {

--- a/app/src/main/java/com/erica/gamsung/post/presentation/PostViewModel.kt
+++ b/app/src/main/java/com/erica/gamsung/post/presentation/PostViewModel.kt
@@ -126,21 +126,21 @@ class PostViewModel
                     reservationId?.let { resId ->
                         imgBitmap?.let {
                             val imgByte = bitmapToByteArray(it)
-                            val requestBody = imgByte.toRequestBody("image/jpeg".toMediaTypeOrNull())
-                            val formData = MultipartBody.Part.createFormData("files", "image.jpg", requestBody)
-                            val filesList = listOf(formData)
-                            val response = postApi.confirmImgData(resId, filesList)
                             if (imgByte.isNotEmpty()) {
+                                val requestBody = imgByte.toRequestBody("image/jpeg".toMediaTypeOrNull())
+                                val formData = MultipartBody.Part.createFormData("files", "image.jpg", requestBody)
+                                val filesList = listOf(formData)
+                                val response = postApi.confirmImgData(resId, filesList)
                                 if (response.isSuccessful) {
                                     val responseBody = response.body()
                                     Log.d("ViewModel", "Image upload successful: $responseBody")
+                                    postApi.confirmPostData(resId, Post(content))
                                 } else {
                                     Log.e("ViewModel", "Error in image upload: ${response.errorBody()?.string()}")
                                 }
                             } else {
                                 Log.e("ViewModel", "Image byte array is empty, skipping upload")
                             }
-                            postApi.confirmPostData(resId, Post(content))
                         } ?: Log.e("ViewModel", "Image Bitmap is null, skipping upload")
                     } ?: Log.e("ViewModel", "Reservation ID is null, cannot upload data")
                 } catch (e: IOException) {


### PR DESCRIPTION
## Issue
- close #92 

## Overview (Required)
- 글 확정 API 호출 후에 인스타그램에 업로드 되지 않던 버그를 수정한다

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

---

이미지 업로드 API -> 글 확정 API 순으로 호출하던 것을
글 확정 API -> 이미지 업로드 API 순으로 호출하도록 수정해서 해결했어.